### PR TITLE
added support for handling optional and try modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ quick guide for that too: https://github.com/nelsonic/learn-hapi
 
 ## Usage
 
-We have tried to make this plugin a user (developer) friendly as possible,
-but if anything is unclear,  
-please submit any questions as issues on GitHub:
+We tried to make this plugin as user (developer) friendly as possible,
+but if anything is unclear, please submit any questions as issues on GitHub:
+
 https://github.com/dwyl/hapi-auth-jwt2/issues
 
 ### Install from NPM
@@ -202,6 +202,15 @@ they are all optional.
 
 This feature was requested in: [issues/29](https://github.com/dwyl/hapi-auth-jwt2/issues/29)
 
+### Authentication Modes
+
+This plugin supports [authentication modes](http://hapijs.com/api#route-options) on routes.
+
+- `required` - requires Authorization header to be sent with every request
+
+- `optional` - if no Authorization header is provided, request will pass with `request.auth.isAuthenticated` set to `true` and `request.auth.credentials` set to empty object
+
+- `try` - similar to `optional` but invalid Authorization header will pass with `request.auth.isAuthenticated` set to false and failed credentials provided in `request.auth.credentials`
 
 - - -
 
@@ -274,11 +283,6 @@ So we decided to write our own module addressing all these issues.
 
 The name we wanted was taken.  
 Think of our module as the "***new, simplified and actively maintained version***"
-
-
-
-
-
 
 ## Useful Links
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,40 +24,49 @@ internals.implementation = function (server, options) {
   var scheme = {
     authenticate: function (request, reply) {
       var auth = request.headers.authorization;
-      if (!auth) {
-        return reply(Boom.unauthorized('Missing auth token'));
+
+      if (!auth && (request.auth.mode === 'optional' || request.auth.mode === 'try')) {
+        return reply.continue({ credentials: {} });
       }
-      else { // strip pointless "Bearer " label & any whitespace > http://git.io/xP4F
-        var token = auth.replace(/Bearer/gi,'').replace(/ /g,'');
-        // rudimentary check for JWT validity see: http://git.io/xPBn for JWT format
-        if (token.split('.').length !== 3) {
-          return reply(Boom.unauthorized('Invalid token format', 'Token'));
+      else {
+        if (!auth) {
+          return reply(Boom.unauthorized('Missing auth token'));
         }
-        else { // attempt to verify the token *asynchronously*
-          var verifyOptions = options.verifyOptions || {};
-          JWT.verify(token, options.key, verifyOptions, function (err, decoded) {
-            if (err) {
-              if (err.name === 'TokenExpiredError') {
-                return reply(Boom.unauthorized('Token expired', 'Token'));
-              }
-              else {
-                return reply(Boom.unauthorized('Invalid token', 'Token'));
-              }
-            }
-            else { // see: http://hapijs.com/tutorials/auth for validateFunc signature
-              options.validateFunc(decoded, request, function (err, valid, credentials) { // bring your own checks
-                if (err) { // err sent as Boom attributes https://github.com/hapijs/boom#boomunauthorizedmessage-scheme-attributes
-                  return reply(Boom.unauthorized('Invalid token', 'Token'), null, err)
-                }
-                else if (!valid) {
-                  return reply(Boom.unauthorized('Invalid credentials', 'Token'), null, { credentials: credentials });
+        else { // strip pointless "Bearer " label & any whitespace > http://git.io/xP4F
+          var token = auth.replace(/Bearer/gi,'').replace(/ /g,'');
+          // rudimentary check for JWT validity see: http://git.io/xPBn for JWT format
+          if (token.split('.').length !== 3) {
+            return reply(Boom.unauthorized('Invalid token format', 'Token'));
+          }
+          else { // attempt to verify the token *asynchronously*
+            var verifyOptions = options.verifyOptions || {};
+            JWT.verify(token, options.key, verifyOptions, function (err, decoded) {
+              if (err) {
+                // for 'try' mode we need to pass back the decoded token even if verification failed
+                var credentials = JWT.decode(token);
+
+                if (err.name === 'TokenExpiredError') {
+                  return reply(Boom.unauthorized('Token expired', 'Token'), null, { credentials: credentials });
                 }
                 else {
-                  return reply.continue({ credentials: credentials || decoded });
+                  return reply(Boom.unauthorized('Invalid token', 'Token'), null, { credentials: credentials });
                 }
-              });
-            }
-          });
+              }
+              else { // see: http://hapijs.com/tutorials/auth for validateFunc signature
+                options.validateFunc(decoded, request, function (err, valid, credentials) { // bring your own checks
+                  if (err) { // err sent as Boom attributes https://github.com/hapijs/boom#boomunauthorizedmessage-scheme-attributes
+                    return reply(Boom.unauthorized('Invalid token', 'Token'), null, err)
+                  }
+                  else if (!valid) {
+                    return reply(Boom.unauthorized('Invalid credentials', 'Token'), null, { credentials: credentials || decoded });
+                  }
+                  else {
+                    return reply.continue({ credentials: credentials || decoded });
+                  }
+                });
+              }
+            });
+          }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-auth-jwt2",
-  "version": "4.3.4",
+  "version": "4.4.0",
   "description": "Hapi.js Authentication Plugin/Scheme using JSON Web Tokens (JWT)",
   "main": "lib/index.js",
   "repository": {

--- a/test/server.js
+++ b/test/server.js
@@ -14,20 +14,20 @@ var db = {
 // defining our own validate function lets us do something
 // useful/custom with the decodedToken before reply(ing)
 var validate = function (decoded, request, callback) {
-    if (db[decoded.id].allowed) {
-      return callback(null, true);
-    }
-    else {
-      return callback('fail', false);
-    }
+  if (db[decoded.id].allowed) {
+    return callback(null, true);
+  }
+  else {
+    return callback('fail', false);
+  }
 };
 
 var home = function(req, reply) {
-    reply('Hai!');
+  return reply('Hai!');
 }
 
 var privado = function(req, reply) {
-  reply('worked');
+  return reply('worked');
 }
 
 server.register(require('../'), function (err) {
@@ -40,6 +40,9 @@ server.register(require('../'), function (err) {
   server.route([
     { method: 'GET',  path: '/', handler: home, config:{ auth: false } },
     { method: 'POST', path: '/privado', handler: privado, config: { auth: 'jwt' } },
+    { method: 'POST', path: '/required', handler: privado, config: { auth: { mode: 'required', strategy: 'jwt' } } },
+    { method: 'POST', path: '/optional', handler: privado, config: { auth: { mode: 'optional', strategy: 'jwt' } } },
+    { method: 'POST', path: '/try', handler: privado, config: { auth: { mode: 'try', strategy: 'jwt' } } },
   ]);
 
 });

--- a/test/test.js
+++ b/test/test.js
@@ -170,3 +170,152 @@ test("Request with undefined auth header should 401", function(t) {
     t.end();
   });
 });
+
+test("Auth mode 'required' should require authentication header", function(t) {
+  var options = {
+    method: "POST",
+    url: "/required"
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 401, "No token header should fail in auth 'required' mode");
+    t.end();
+  });
+});
+
+test("Auth mode 'required' should fail with invalid token", function(t) {
+  // use the token as the 'authorization' header in requests
+  var token = JWT.sign({ id:123,"name":"Charlie" }, 'badsecret');
+  var options = {
+    method: "POST",
+    url: "/required",
+    headers: { authorization: "Bearer "+token }
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    console.log(" - - - - RESPONSE: ")
+    console.log(response.result);
+    t.equal(response.statusCode, 401, "Invalid token should error!");
+
+    t.end();
+  });
+});
+
+test("Auth mode 'required' should should pass with valid token", function(t) {
+  // use the token as the 'authorization' header in requests
+  var token = JWT.sign({ id:123,"name":"Charlie" }, secret);
+  var options = {
+    method: "POST",
+    url: "/required",
+    headers: { authorization: "Bearer "+token }
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    console.log(" - - - - RESPONSE: ")
+    console.log(response.result);
+    t.equal(response.statusCode, 200, "Valid token should succeed!");
+
+    t.end();
+  });
+});
+
+test("Auth mode 'optional' should pass when no auth header specified", function(t) {
+  var options = {
+    method: "POST",
+    url: "/optional"
+  };
+  server.inject(options, function(response) {
+    console.log(" - - - - RESPONSE: ")
+    console.log(response.result);
+    t.equal(response.statusCode, 200, "No auth header should pass in optional mode!");
+
+    t.end();
+  });
+});
+
+test("Auth mode 'optional' should fail with invalid token", function(t) {
+  // use the token as the 'authorization' header in requests
+  var token = JWT.sign({ id:123,"name":"Charlie" }, 'badsecret');
+  var options = {
+    method: "POST",
+    url: "/optional",
+    headers: { authorization: "Bearer "+token }
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    console.log(" - - - - RESPONSE: ")
+    console.log(response.result);
+    t.equal(response.statusCode, 401, "Invalid token should error!");
+
+    t.end();
+  });
+});
+
+test("Auth mode 'optional' should pass with valid token", function(t) {
+  // use the token as the 'authorization' header in requests
+  // var token = JWT.sign({ id:123,"name":"Charlie" }, secret);
+  var token = JWT.sign({ id:123,"name":"Charlie" }, secret);
+  var options = {
+    method: "POST",
+    url: "/optional",
+    headers: { authorization: "Bearer "+token }
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    console.log(" - - - - RESPONSE: ")
+    console.log(response.result);
+    t.equal(response.statusCode, 200, "Valid token should succeed!");
+
+    t.end();
+  });
+});
+
+test("Auth mode 'try' should pass when no auth header specified", function(t) {
+  var options = {
+    method: "POST",
+    url: "/try"
+  };
+  server.inject(options, function(response) {
+    console.log(" - - - - RESPONSE: ")
+    console.log(response.result);
+    t.equal(response.statusCode, 200, "No auth header should pass in 'try' mode!");
+
+    t.end();
+  });
+});
+
+test("Auth mode 'try' should pass with invalid token", function(t) {
+  // use the token as the 'authorization' header in requests
+  var token = JWT.sign({ id:123,"name":"Charlie" }, 'badsecret');
+  var options = {
+    method: "POST",
+    url: "/try",
+    headers: { authorization: "Bearer "+token }
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    console.log(" - - - - RESPONSE: ")
+    console.log(response.result);
+    t.equal(response.statusCode, 200, "Invalid token should pass in 'try' mode");
+
+    t.end();
+  });
+});
+
+test("Auth mode 'try' should pass with valid token", function(t) {
+  // use the token as the 'authorization' header in requests
+  var token = JWT.sign({ id:123,"name":"Charlie" }, secret);
+  var options = {
+    method: "POST",
+    url: "/try",
+    headers: { authorization: "Bearer "+token }
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    console.log(" - - - - RESPONSE: ")
+    console.log(response.result);
+    t.equal(response.statusCode, 200, "Valid token should succeed!");
+
+    t.end();
+  });
+});


### PR DESCRIPTION
Added a check to see whether or not the auth mode is `optional` or `try`. If it is and no auth header is provided, we pass through with empty credentials. I'm not sure if this is what the hapi standard is because this sets `request.auth.credentials.isAuthenticated` to true. I suppose if you specify `optional` or `try` and no header is given you're assuming this user is authenticated.

The other thing I added was a `jwt.decode` in the jwt callback if we get an error. Hapi expects that in `try` mode we provide the credentials even if they did *not* pass. That's the whole point of `try` mode...even if a user is not authenticated we want to see what he tried to authenticate with.

Other than that I fixed a bit of formatting here and there and added routes to server.js for testing different modes.