### PR TITLE
Fixed repository references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: node_js
 node_js:
   - 0.10
   - 0.12
-  - iojs
+  - 'iojs-v2.1.0'
 env:
   - JWT_SECRET="EverythingIsAwesome!"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dwyl/hapi-auth-jwt.git"
+    "url": "https://github.com/dwyl/hapi-auth-jwt2.git"
   },
   "keywords": [
     "Hapi.js",
@@ -21,9 +21,9 @@
   }],
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/dwyl/hapi-auth-jwt/issues"
+    "url": "https://github.com/dwyl/hapi-auth-jwt2/issues"
   },
-  "homepage": "https://github.com/dwyl/hapi-auth-jwt",
+  "homepage": "https://github.com/dwyl/hapi-auth-jwt2",
   "dependencies": {
     "boom": "^2.7.0",
     "hoek": "^2.13.0",


### PR DESCRIPTION
[npm's listing](https://www.npmjs.com/package/hapi-auth-jwt2) has the wrong repository URLs. This should fix the issue when you do your next `publish` to npm.