### PR TITLE
Token via URI Expansion Pack!

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ signature `function(decoded, callback)` where:
     - `audience` - do not enforce token [*audience*](http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#audDef)
     - `issuer` - do not require the issuer to be valid
     - `algorithms` - list of allowed algorithms
+- `url tokens` - if you prefer to pass your token in via url, simply add a `token` url parameter to your reqest.
 
 ### verifyOptions let you define how to Verify the Tokens (*Optional*)
 
@@ -236,6 +237,20 @@ This plugin supports [authentication modes](http://hapijs.com/api#route-options)
 - This option to look up a secret key was added to support "multi-tenant" environments. One use case would be companies that white label API services for their customers and cannot use a shared secret key.
 
 - The reason why you might want to pass back `extraInfo` in the callback is because you likely need to do a database call to get the key which also probably returns useful user data. This could save you another call in `validateFunc`.
+
+## URL (URI) Token
+
+Several people requested the ability pass in JSNOWebTokens via request URL:
+https://github.com/dwyl/hapi-auth-jwt2/issues/19
+
+### Usage
+
+Setup your hapi.js server as described above (_no special setup for using jwt tokens in urls_)
+
+```sh
+https://yoursite.co/path?token=your.jsonwebtoken.here
+```
+You will need to generage valid tokens for this to work.
 
 - - -
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,22 @@ https://yoursite.co/path?token=your.jsonwebtoken.here
 ```
 You will need to generage valid tokens for this to work.
 
+```js
+var JWT   = require('jsonwebtoken');
+var obj   = { id:123,"name":"Charlie" }; // object/info you want to sign
+var token = JWT.sign(obj, secret);
+var url   = "/path?token="+token;
+```
+
+## Generating Your Secret Key
+
+@skota asked "_How to generate secret key_?" in: https://github.com/dwyl/hapi-auth-jwt2/issues/48
+
+There are _several_ options for generating secret keys.
+The _easist_ way is to simply copy paste a _**strong random string**_ of alpha-numeric characters from https://www.grc.com/passwords.htm
+(_if you want more a longer key simply refresh the page and copy-paste multiple random strings_)
+
+
 - - -
 
 ## Frequently Asked Questions (FAQ)

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,6 @@ internals.implementation = function (server, options) {
       var auth;
       // tokens via url: https://github.com/dwyl/hapi-auth-jwt2/issues/19
       if(request.query.token) {
-        console.log(request.query.token);
         auth = request.query.token;
       }
       else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,15 @@ internals.implementation = function (server, options) {
 
   var scheme = {
     authenticate: function (request, reply) {
-      var auth = request.headers.authorization;
+      var auth;
+      // tokens via url: https://github.com/dwyl/hapi-auth-jwt2/issues/19
+      if(request.query.token) {
+        console.log(request.query.token);
+        auth = request.query.token;
+      }
+      else {
+        auth = request.headers.authorization;
+      }
 
       if (!auth && (request.auth.mode === 'optional' || request.auth.mode === 'try')) {
         return reply.continue({ credentials: {} });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-auth-jwt2",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "description": "Hapi.js Authentication Plugin/Scheme using JSON Web Tokens (JWT)",
   "main": "lib/index.js",
   "repository": {

--- a/test/test.js
+++ b/test/test.js
@@ -74,7 +74,6 @@ test("Try using an incorrect secret to sign the JWT", function(t) {
   // server.inject lets us similate an http request
   server.inject(options, function(response) {
     t.equal(response.statusCode, 401, "Token signed with incorrect key fails");
-  t.equal(true, true, "true is true")
     t.end();
   });
 });
@@ -94,7 +93,6 @@ test("Try using an expired token", function(t) {
     server.inject(options, function(response) {
       t.equal(response.statusCode, 401, "Expired token should be invalid");
       t.equal(response.result.message, 'Token expired', 'Message should be "Token expired"')
-    t.equal(true, true, "true is true")
       t.end();
     });
   }, 1000);
@@ -126,10 +124,9 @@ test("Access restricted content (with VALID Token)", function(t) {
   };
   // server.inject lets us similate an http request
   server.inject(options, function(response) {
-    console.log(" - - - - RESPONSE: ")
-    console.log(response.result);
+    // console.log(" - - - - RESPONSE: ")
+    // console.log(response.result);
     t.equal(response.statusCode, 200, "VALID Token should succeed!");
-
     t.end();
   });
 });
@@ -144,10 +141,9 @@ test("Access restricted content (with Well-formed but invalid Token)", function(
   };
   // server.inject lets us similate an http request
   server.inject(options, function(response) {
-    console.log(" - - - - RESPONSE: ")
-    console.log(response.result);
+    // console.log(" - - - - RESPONSE: ")
+    // console.log(response.result);
     t.equal(response.statusCode, 401, "InVALID Token should Error!");
-
     t.end();
   });
 });
@@ -163,8 +159,8 @@ test("Request with undefined auth header should 401", function(t) {
   };
   // server.inject lets us similate an http request
   server.inject(options, function(response) {
-    console.log(" - - - - RESPONSE: ")
-    console.log(response.result);
+    // console.log(" - - - - RESPONSE: ")
+    // console.log(response.result);
     t.equal(response.statusCode, 401, "InVALID Token fails (as expected)!");
 
     t.end();
@@ -193,10 +189,9 @@ test("Auth mode 'required' should fail with invalid token", function(t) {
   };
   // server.inject lets us similate an http request
   server.inject(options, function(response) {
-    console.log(" - - - - RESPONSE: ")
-    console.log(response.result);
+    // console.log(" - - - - RESPONSE: ")
+    // console.log(response.result);
     t.equal(response.statusCode, 401, "Invalid token should error!");
-
     t.end();
   });
 });
@@ -211,10 +206,9 @@ test("Auth mode 'required' should should pass with valid token", function(t) {
   };
   // server.inject lets us similate an http request
   server.inject(options, function(response) {
-    console.log(" - - - - RESPONSE: ")
-    console.log(response.result);
+    // console.log(" - - - - RESPONSE: ")
+    // console.log(response.result);
     t.equal(response.statusCode, 200, "Valid token should succeed!");
-
     t.end();
   });
 });
@@ -225,10 +219,9 @@ test("Auth mode 'optional' should pass when no auth header specified", function(
     url: "/optional"
   };
   server.inject(options, function(response) {
-    console.log(" - - - - RESPONSE: ")
-    console.log(response.result);
+    // console.log(" - - - - RESPONSE: ")
+    // console.log(response.result);
     t.equal(response.statusCode, 200, "No auth header should pass in optional mode!");
-
     t.end();
   });
 });
@@ -243,10 +236,9 @@ test("Auth mode 'optional' should fail with invalid token", function(t) {
   };
   // server.inject lets us similate an http request
   server.inject(options, function(response) {
-    console.log(" - - - - RESPONSE: ")
-    console.log(response.result);
+    // console.log(" - - - - RESPONSE: ")
+    // console.log(response.result);
     t.equal(response.statusCode, 401, "Invalid token should error!");
-
     t.end();
   });
 });
@@ -262,10 +254,9 @@ test("Auth mode 'optional' should pass with valid token", function(t) {
   };
   // server.inject lets us similate an http request
   server.inject(options, function(response) {
-    console.log(" - - - - RESPONSE: ")
-    console.log(response.result);
+    // console.log(" - - - - RESPONSE: ")
+    // console.log(response.result);
     t.equal(response.statusCode, 200, "Valid token should succeed!");
-
     t.end();
   });
 });
@@ -276,10 +267,9 @@ test("Auth mode 'try' should pass when no auth header specified", function(t) {
     url: "/try"
   };
   server.inject(options, function(response) {
-    console.log(" - - - - RESPONSE: ")
-    console.log(response.result);
+    // console.log(" - - - - RESPONSE: ")
+    // console.log(response.result);
     t.equal(response.statusCode, 200, "No auth header should pass in 'try' mode!");
-
     t.end();
   });
 });
@@ -294,10 +284,9 @@ test("Auth mode 'try' should pass with invalid token", function(t) {
   };
   // server.inject lets us similate an http request
   server.inject(options, function(response) {
-    console.log(" - - - - RESPONSE: ")
-    console.log(response.result);
+    // console.log(" - - - - RESPONSE: ")
+    // console.log(response.result);
     t.equal(response.statusCode, 200, "Invalid token should pass in 'try' mode");
-
     t.end();
   });
 });
@@ -312,10 +301,9 @@ test("Auth mode 'try' should pass with valid token", function(t) {
   };
   // server.inject lets us similate an http request
   server.inject(options, function(response) {
-    console.log(" - - - - RESPONSE: ")
-    console.log(response.result);
+    // console.log(" - - - - RESPONSE: ")
+    // console.log(response.result);
     t.equal(response.statusCode, 200, "Valid token should succeed!");
-
     t.end();
   });
 });

--- a/test/url-token-server.js
+++ b/test/url-token-server.js
@@ -1,0 +1,51 @@
+var Hapi   = require('hapi');
+var JWT    = require('jsonwebtoken');
+var secret = 'NeverShareYourSecret';
+
+// for debug options see: http://hapijs.com/tutorials/logging
+var server = new Hapi.Server({ debug: false })
+server.connection();
+
+var db = {
+  "123" : { allowed: true,  "name":"Charlie"  },
+  "321" : { allowed: false, "name":"Old Gregg"}
+ }
+
+// defining our own validate function lets us do something
+// useful/custom with the decodedToken before reply(ing)
+var validate = function (decoded, request, callback) {
+  if (db[decoded.id].allowed) {
+    return callback(null, true);
+  }
+  else {
+    return callback('fail', false);
+  }
+};
+
+var home = function(req, reply) {
+  return reply('Hai!');
+}
+
+var privado = function(req, reply) {
+  return reply('worked');
+}
+
+server.register(require('../'), function (err) {
+
+  server.auth.strategy('jwt', 'jwt', {
+    key: secret,
+    validateFunc: validate,
+    verifyOptions: { algorithms: [ 'HS256' ] } // only allow HS256 algorithm
+  });
+
+  server.route([
+    { method: 'GET',  path: '/', handler: home, config:{ auth: false } },
+    { method: 'POST', path: '/privado', handler: privado, config: { auth: 'jwt' } },
+    { method: 'POST', path: '/required', handler: privado, config: { auth: { mode: 'required', strategy: 'jwt' } } },
+    { method: 'POST', path: '/optional', handler: privado, config: { auth: { mode: 'optional', strategy: 'jwt' } } },
+    { method: 'POST', path: '/try', handler: privado, config: { auth: { mode: 'try', strategy: 'jwt' } } },
+  ]);
+
+});
+
+module.exports = server;

--- a/test/url-token-test.js
+++ b/test/url-token-test.js
@@ -1,0 +1,78 @@
+var test   = require('tape');
+var JWT    = require('jsonwebtoken');
+var secret = 'NeverShareYourSecret';
+
+var server = require('./url-token-server.js');
+
+test("Attempt to access restricted content (without auth token)", function(t) {
+  var options = {
+    method: "POST",
+    url: "/privado"
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 401, "No Token supplied > fails (as expected)");
+    t.end();
+  });
+});
+
+test("Attempt to access restricted content (with an INVALID URL Token)", function(t) {
+  var token = "?token=my.invalid.token";
+  var options = {
+    method: "POST",
+    url: "/privado"
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 401, "INVALID Token should fail");
+    t.end();
+  });
+});
+
+test("Try using an incorrect secret to sign the JWT", function(t) {
+  // use the token as the 'authorization' header in requests
+  var token = JWT.sign({ id:123,"name":"Charlie" }, 'incorrectSecret');
+  token = "?token="+token
+  console.log(" - - - - - - token  - - - - -")
+  console.log(token);
+  var options = {
+    method: "POST",
+    url: "/privado"+token
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 401, "URL Token signed with incorrect key fails");
+    t.end();
+  });
+});
+
+test("URL Token is well formed but is allowed=false so should be denied", function(t) {
+  // use the token as the 'authorization' header in requests
+  // var token = jwt.sign({ "id": 1 ,"name":"Old Greg" }, 'incorrectSecret');
+  var token = JWT.sign({ id:321,"name":"Old Gregg" }, secret);
+  token = "?token="+token
+  var options = {
+    method: "POST",
+    url: "/privado"+token
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 401, "User is Denied");
+    t.end();
+  });
+});
+
+test("Access restricted content (with VALID Token)", function(t) {
+  // use the token as the 'authorization' header in requests
+  var token = JWT.sign({ id:123,"name":"Charlie" }, secret);
+  token = "?token="+token
+  var options = {
+    method: "POST",
+    url: "/privado"+token
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 200, "VALID Token should succeed!");
+    t.end();
+  });
+});


### PR DESCRIPTION
Adds a line to package to enable JWTs in urls as `token` parameter
as discussed in: https://github.com/dwyl/hapi-auth-jwt2/issues/19