### PR TITLE
Move check for authorization header up in the logic stack

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,15 +30,15 @@ internals.implementation = function (server, options) {
       if(request.query.token) { // tokens via url: https://github.com/dwyl/hapi-auth-jwt2/issues/19
         auth = request.query.token;
       } // JWT tokens in cookie: https://github.com/dwyl/hapi-auth-jwt2/issues/55
+      else if (request.headers.authorization) {
+        auth = request.headers.authorization;
+      }
       else if (request.headers.cookie) {
         var cookie = request.headers.cookie.replace(/token=/gi, '');
         if(cookie.indexOf(';') > -1) { // cookie has options set
           cookie = cookie.substring(0, cookie.indexOf(';'));
         }
         auth = cookie;
-      }
-      else {
-        auth = request.headers.authorization;
       }
       if (!auth && (request.auth.mode === 'optional' || request.auth.mode === 'try')) {
         return reply.continue({ credentials: {} });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-auth-jwt2",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "Hapi.js Authentication Plugin/Scheme using JSON Web Tokens (JWT)",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
This may not quite fix the problem entirely mention in #65, but I think it's a start.

The final fix would be to also somehow use a regex to confirm not only that a cookie is present, but that the token actually exists in it.

I'm just not super familiar with the full scope of what cookies with a bunch of junk in them look like to write that RegEx