### PR TITLE
Fix reply called twice error. Avoid side effects in extract.

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -1,20 +1,13 @@
 var Cookie = require('cookie'); // highly popular decoupled cookie parser
 var Boom = require('boom'); // error handling https://github.com/hapijs/boom
 
-function basicChecks (token, request, reply) {
- // rudimentary check for JWT validity see: http://git.io/xPBn for JWT format
- if (token.split('.').length !== 3) {
-   return reply(Boom.unauthorized('Invalid token format', 'Token'));
- }
- return true;
-}
-
  /**
   * Extract the JWT from URL, Auth Header or Cookie
   */
 
-module.exports = function (request, reply) {
-  var auth, token;
+module.exports = function (request) {
+  var auth;
+
   if(request.query.token) { // tokens via url: https://github.com/dwyl/hapi-auth-jwt2/issues/19
     auth = request.query.token;
   } // JWT tokens in cookie: https://github.com/dwyl/hapi-auth-jwt2/issues/55
@@ -24,14 +17,15 @@ module.exports = function (request, reply) {
   else if (request.headers.cookie) {
     auth = Cookie.parse(request.headers.cookie).token;
   }
-  if (!auth && (request.auth.mode === 'optional' || request.auth.mode === 'try')) {
-    return reply.continue({ credentials: {} });
-  }
-  if (!auth) {
-    return reply(Boom.unauthorized('Missing auth token'));
-  }
+
   // strip pointless "Bearer " label & any whitespace > http://git.io/xP4F
-  token = auth.replace(/Bearer/gi,'').replace(/ /g,'');
-  basicChecks(token, request, reply);
-  return token;
+  return auth ? auth.replace(/Bearer/gi,'').replace(/ /g,'') : null;
+}
+
+module.exports.isValid = function basicChecks (token) {
+ // rudimentary check for JWT validity see: http://git.io/xPBn for JWT format
+ if (token.split('.').length !== 3) {
+   return false;
+ }
+ return true;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,19 @@ internals.implementation = function (server, options) {
   return {
     authenticate: function (request, reply) {
       var token = extract(request, reply);
+
+      if (!token && request.auth.mode === 'optional') {
+        return reply.continue({ credentials: {} });
+      }
+
+      if (!token) {
+        return reply(Boom.unauthorized('Missing auth token'));
+      }
+
+      if (!extract.isValid(token)) {
+        return reply(Boom.unauthorized('Invalid token format', 'Token'));
+      }
+
       var keyFunc = (internals.isFunction(options.key)) ? options.key : function (decoded, callback) { callback(null, options.key); };
       keyFunc(JWT.decode(token), function (err, key, extraInfo) {
         if (err) {


### PR DESCRIPTION
`extract` has side effects - it could extract the token from your request, or it might respond to the client. This PR ensures `extract` only extracts a token from a request, or returns `null` if no token is found.

Secondly, we don't `reply.continue` if the auth mode is "try" since hapi deals with this and will call your request handler with isAuthenticated set to `false`.