### PR TITLE
urlKey and cookieKey options

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,8 @@ signature `function(decoded, callback)` where:
     - `audience` - do not enforce token [*audience*](http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#audDef)
     - `issuer` - do not require the issuer to be valid
     - `algorithms` - list of allowed algorithms
-- `url tokens` - if you prefer to pass your token in via url, simply add a `token` url parameter to your reqest.
-- `cookie token` - If you prefer to use cookies in your hapi.js app,
-simply set the cookie `token=your.jsonwebtoken.here`
+- `urlKey` - (***optional***) if you prefer to pass your token via url, simply add a `token` url parameter to your request or use a custom parameter by setting `urlKey`
+- `cookieKey` - (***optional***) if you prefer to pass your token via a cookie, simply set the cookie `token=your.jsonwebtoken.here` or use a custom key by setting `cookieKey`
 
 ### verifyOptions let you define how to Verify the Tokens (*Optional*)
 

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -5,27 +5,28 @@ var Boom = require('boom'); // error handling https://github.com/hapijs/boom
   * Extract the JWT from URL, Auth Header or Cookie
   */
 
-module.exports = function (request) {
+module.exports = function (request, options) {
+  
+  // Allows customization of the key holding token value in url or cookie
+  var urlKey = typeof options.urlKey === 'string' ? options.urlKey : 'token';
+  var cookieKey = typeof options.cookieKey === 'string' ? options.cookieKey : 'token';
   var auth;
-
+  
   if(request.query.token) { // tokens via url: https://github.com/dwyl/hapi-auth-jwt2/issues/19
-    auth = request.query.token;
+    auth = request.query[urlKey];
   } // JWT tokens in cookie: https://github.com/dwyl/hapi-auth-jwt2/issues/55
   else if (request.headers.authorization) {
     auth = request.headers.authorization;
   }
   else if (request.headers.cookie) {
-    auth = Cookie.parse(request.headers.cookie).token;
+    auth = Cookie.parse(request.headers.cookie)[cookieKey];
   }
 
   // strip pointless "Bearer " label & any whitespace > http://git.io/xP4F
   return auth ? auth.replace(/Bearer/gi,'').replace(/ /g,'') : null;
-}
+};
 
 module.exports.isValid = function basicChecks (token) {
  // rudimentary check for JWT validity see: http://git.io/xPBn for JWT format
- if (token.split('.').length !== 3) {
-   return false;
- }
- return true;
-}
+ return token.split('.').length === 3;
+};

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -7,12 +7,12 @@ var Boom = require('boom'); // error handling https://github.com/hapijs/boom
 
 module.exports = function (request, options) {
   
-  // Allows customization of the key holding token value in url or cookie
+  // The key holding token value in url or cookie defaults to token
   var urlKey = typeof options.urlKey === 'string' ? options.urlKey : 'token';
   var cookieKey = typeof options.cookieKey === 'string' ? options.cookieKey : 'token';
   var auth;
   
-  if(request.query.token) { // tokens via url: https://github.com/dwyl/hapi-auth-jwt2/issues/19
+  if(request.query[urlKey]) { // tokens via url: https://github.com/dwyl/hapi-auth-jwt2/issues/19
     auth = request.query[urlKey];
   } // JWT tokens in cookie: https://github.com/dwyl/hapi-auth-jwt2/issues/55
   else if (request.headers.authorization) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,20 +26,20 @@ internals.implementation = function (server, options) {
 
   return {
     authenticate: function (request, reply) {
-      var token = extract(request, reply);
-
+      var token = extract(request, options);
+      
       if (!token && request.auth.mode === 'optional') {
         return reply.continue({ credentials: {} });
       }
-
+      
       if (!token) {
         return reply(Boom.unauthorized('Missing auth token'));
       }
-
+      
       if (!extract.isValid(token)) {
         return reply(Boom.unauthorized('Invalid token format', 'Token'));
       }
-
+      
       var keyFunc = (internals.isFunction(options.key)) ? options.key : function (decoded, callback) { callback(null, options.key); };
       keyFunc(JWT.decode(token), function (err, key, extraInfo) {
         if (err) {
@@ -59,7 +59,7 @@ internals.implementation = function (server, options) {
           else { // see: http://hapijs.com/tutorials/auth for validateFunc signature
             options.validateFunc(decoded, request, function (err, valid, credentials) { // bring your own checks
               if (err) {
-                return reply(Boom.unauthorized('Invalid token', 'Token'), null, err)
+                return reply(Boom.unauthorized('Invalid token', 'Token'), null, err);
               }
               else if (!valid) {
                 return reply(Boom.unauthorized('Invalid credentials', 'Token'), null, { credentials: credentials || decoded });

--- a/test/custom-parameters-server.js
+++ b/test/custom-parameters-server.js
@@ -1,0 +1,48 @@
+var Hapi   = require('hapi');
+var JWT    = require('jsonwebtoken');
+var secret = 'NeverShareYourSecret';
+
+// for debug options see: http://hapijs.com/tutorials/logging
+var server = new Hapi.Server({ debug: false });
+server.connection();
+
+var db = {
+  "123" : { allowed: true,  "name":"Charlie"  },
+  "321" : { allowed: false, "name":"Old Gregg"}
+};
+
+// defining our own validate function lets us do something
+// useful/custom with the decodedToken before reply(ing)
+var validate = function (decoded, request, callback) {
+  return db[decoded.id].allowed ? callback(null, true) : callback('fail', false);
+};
+
+var home = function(req, reply) {
+  return reply('Hai!');
+};
+
+var privado = function(req, reply) {
+  return reply('worked');
+};
+
+server.register(require('../'), function (err) {
+
+  server.auth.strategy('jwt', 'jwt', {
+    key: secret,
+    validateFunc: validate,
+    verifyOptions: { algorithms: [ 'HS256' ] },
+    urlKey: 'customUrlKey', // This is really what we are testing here
+    cookieKey: 'customCookieKey' // idem
+  });
+
+  server.route([
+    { method: 'GET',  path: '/', handler: home, config:{ auth: false } },
+    { method: 'POST', path: '/privado', handler: privado, config: { auth: 'jwt' } },
+    { method: 'POST', path: '/required', handler: privado, config: { auth: { mode: 'required', strategy: 'jwt' } } },
+    { method: 'POST', path: '/optional', handler: privado, config: { auth: { mode: 'optional', strategy: 'jwt' } } },
+    { method: 'POST', path: '/try', handler: privado, config: { auth: { mode: 'try', strategy: 'jwt' } } },
+  ]);
+
+});
+
+module.exports = server;

--- a/test/custom-parameters-test.js
+++ b/test/custom-parameters-test.js
@@ -1,0 +1,204 @@
+var test   = require('tape');
+var JWT    = require('jsonwebtoken');
+var secret = 'NeverShareYourSecret';
+var server = require('./custom-parameters-server.js');
+var cookie_options = '; Max-Age=31536000;'; //' Expires=Mon, 18 Jul 2016 05:29:45 GMT; Secure; HttpOnly';
+
+// Those tests are the same as cookie-test and url-token-test but with custom parameters in cookie or URL
+
+test("Attempt to access restricted content using inVALID Cookie Token - custom parameters", function(t) {
+  var token = JWT.sign({ id:123,"name":"Charlie" }, 'badsecret');
+  var options = {
+    method: "POST",
+    url: "/privado",
+    headers: { cookie : "customCookieKey=" + token}
+  };
+  console.log(options);
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 401, "Invalid token should error!");
+    t.end();
+  });
+});
+
+test("Attempt to access restricted content with VALID Token but malformed Cookie - custom parameters", function(t) {
+  var token  = JWT.sign({ id:123,"name":"Charlie" }, secret);
+  var options = {
+    method: "POST",
+    url: "/privado",
+    headers: { cookie : token }
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 400, "Valid Token but inVALID COOKIE should fial!");
+    t.end();
+  });
+});
+
+test("Access restricted content with VALID Token Cookie - custom parameters", function(t) {
+  var token  = JWT.sign({ id:123,"name":"Charlie" }, secret);
+  var options = {
+    method: "POST",
+    url: "/privado",
+    headers: { cookie : "customCookieKey=" + token }
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 200, "VALID COOKIE Token should succeed!");
+    t.end();
+  });
+});
+
+test("Access restricted content with VALID Token Cookie (With Options!) - custom parameters", function(t) {
+  var token  = JWT.sign({ id:123,"name":"Charlie" }, secret);
+  var options = {
+    method: "POST",
+    url: "/privado",
+    headers: { cookie : "customCookieKey=" + token + cookie_options  }
+  };
+  // console.log(' - - - - - - - - - - - - - - - OPTIONS:')
+  // console.log(options);
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    // console.log(' - - - - - - - - - - - - - - - response:')
+    // console.log(response);
+    t.equal(response.statusCode, 200, "VALID COOKIE Token (With Options!) should succeed!");
+    t.end();
+  });
+});
+
+/** Regressions Tests for https://github.com/dwyl/hapi-auth-jwt2/issues/65 **/
+
+// supply valid Token Auth Header but invalid Cookie
+// should succeed because Auth Header is first
+test("Authorization Header should take precedence over any cookie - custom parameters", function(t) {
+  var token    = JWT.sign({ id:123,"name":"Charlie" }, secret);
+  var options = {
+    method: "POST",
+    url: "/privado",
+    headers: {
+      authorization: "Bearer "+token,
+      cookie : "customCookieKey=malformed.token" + cookie_options
+    }
+  };
+  server.inject(options, function(response) {
+    // console.log(' - - - - - - - - - - - - - - - response:')
+    // console.log(response);
+    t.equal(response.statusCode, 200, "Ignores cookie when Auth Header is set");
+    t.end();
+  });
+});
+
+// valid google analytics cookie but invalid auth header token
+// see: https://github.com/dwyl/hapi-auth-jwt2/issues/65#issuecomment-124791842
+test("Valid Google Analytics cookie should be ignored - custom parameters", function(t) {
+  var GA = "gwcm=%7B%22expires%22%3Anull%2C%22clabel%22%3A%22SbNVCILRtFcQwcrE6gM%22%2C%22backoff%22%3A1437241242%7D; _ga=GA1.2.1363734468.1432273334";
+  var token    = JWT.sign({ id:123,"name":"Charlie" }, secret);
+  var options = {
+    method: "POST",
+    url: "/privado",
+    headers: {
+      authorization: "Bearer "+token,
+      cookie : GA
+    }
+  };
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 200, "Ignores Google Analytics Cookie");
+    t.end();
+  });
+});
+
+test("Valid Google Analytics cookie should be ignored (BAD Header Token) - custom parameters", function(t) {
+  var GA = "gwcm=%7B%22expires%22%3Anull%2C%22clabel%22%3A%22SbNVCILRtFcQwcrE6gM%22%2C%22backoff%22%3A1437241242%7D; _ga=GA1.2.1363734468.1432273334";
+  var token    = JWT.sign({ id:123,"name":"Charlie" }, 'invalid');
+  var options = {
+    method: "POST",
+    url: "/privado",
+    headers: {
+      authorization: "Bearer "+token,
+      cookie : GA
+    }
+  };
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 401, "Ignores GA but Invalid Auth Header still rejected");
+    t.end();
+  });
+});
+
+// Supply a VALID Token in Cookie A-N-D valid GA in Cookie!!
+test("Valid Google Analytics cookie should be ignored (BAD Header Token) - custom parameters", function(t) {
+  var GA = "gwcm=%7B%22expires%22%3Anull%2C%22clabel%22%3A%22SbNVCILRtFcQwcrE6gM%22%2C%22backoff%22%3A1437241242%7D; _ga=GA1.2.1363734468.1432273334";
+  var token    = JWT.sign({ id:123,"name":"Charlie" }, secret);
+  var options = {
+    method: "POST",
+    url: "/privado",
+    headers: {
+      cookie : "customCookieKey=" + token + '; ' + GA
+    }
+  };
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 200, "Valid Cookie Token Succeeds (Ignores GA)");
+    t.end();
+  });
+});
+
+
+test("Attempt to access restricted content (with an INVALID URL Token) - custom parameters", function(t) {
+  var token = "?customUrlKey=my.invalid.token";
+  var options = {
+    method: "POST",
+    url: "/privado" + token
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 401, "INVALID Token should fail");
+    t.end();
+  });
+});
+
+test("Try using an incorrect secret to sign the JWT - custom parameters", function(t) {
+  // use the token as the 'authorization' header in requests
+  var token = JWT.sign({ id:123,"name":"Charlie" }, 'incorrectSecret');
+  token = "?customUrlKey=" + token;
+  // console.log(" - - - - - - token  - - - - -")
+  // console.log(token);
+  var options = {
+    method: "POST",
+    url: "/privado" + token
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 401, "URL Token signed with incorrect key fails");
+    t.end();
+  });
+});
+
+test("URL Token is well formed but is allowed=false so should be denied - custom parameters", function(t) {
+  // use the token as the 'authorization' header in requests
+  // var token = jwt.sign({ "id": 1 ,"name":"Old Greg" }, 'incorrectSecret');
+  var token = JWT.sign({ id:321,"name":"Old Gregg" }, secret);
+  token = "?customUrlKey=" + token;
+  var options = {
+    method: "POST",
+    url: "/privado" + token
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 401, "User is Denied");
+    t.end();
+  });
+});
+
+test("Access restricted content (with VALID Token) - custom parameters", function(t) {
+  // use the token as the 'authorization' header in requests
+  var token = JWT.sign({ id:123,"name":"Charlie" }, secret);
+  token = "?customUrlKey=" + token;
+  var options = {
+    method: "POST",
+    url: "/privado" + token
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 200, "VALID Token should succeed!");
+    t.end();
+  });
+});

--- a/test/url-token-test.js
+++ b/test/url-token-test.js
@@ -20,7 +20,7 @@ test("Attempt to access restricted content (with an INVALID URL Token)", functio
   var token = "?token=my.invalid.token";
   var options = {
     method: "POST",
-    url: "/privado"
+    url: "/privado" + token
   };
   // server.inject lets us similate an http request
   server.inject(options, function(response) {


### PR DESCRIPTION
Hi,

This PR allows to specify a custom URL parameter or cookie key for passing the JWT.

```javascript
server.auth.strategy('jwt', 'jwt', true,
    { key: 'NeverShareYourSecret',          // Never Share your secret key
      validateFunc: validate,            // validate function defined above
      verifyOptions: { algorithms: [ 'HS256' ] }, // pick a strong algorithm
      urlKey: 'customKeysAreCool', // now one can request http://foo.bar/customKeysAreCool=j.w.t
      cookieKey: 'imCustomToo' // cookie : imCustomToo=j.w.t
    });
```

It still defaults to `token`. I updated the readme as well.
Hope this can be useful.