### PR TITLE
resolves #77 error in validateFunc causes correct 500 series response to be sent to client

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,7 @@ internals.implementation = function (server, options) {
           else { // see: http://hapijs.com/tutorials/auth for validateFunc signature
             options.validateFunc(decoded, request, function (err, valid, credentials) { // bring your own checks
               if (err) {
-                return reply(Boom.unauthorized('Invalid token', 'Token'), null, err);
+                return reply(Boom.wrap(err));
               }
               else if (!valid) {
                 return reply(Boom.unauthorized('Invalid credentials', 'Token'), null, { credentials: credentials || decoded });

--- a/test/custom-parameters-server.js
+++ b/test/custom-parameters-server.js
@@ -14,7 +14,7 @@ var db = {
 // defining our own validate function lets us do something
 // useful/custom with the decodedToken before reply(ing)
 var validate = function (decoded, request, callback) {
-  return db[decoded.id].allowed ? callback(null, true) : callback('fail', false);
+  return db[decoded.id].allowed ? callback(null, true) : callback(null, false);
 };
 
 var home = function(req, reply) {

--- a/test/dynamic-key-server.js
+++ b/test/dynamic-key-server.js
@@ -45,7 +45,7 @@ var validate = function (decoded, request, callback) {
     return callback(null, true, credentials);
   }
   else {
-    return callback('fail', false);
+    return callback(null, false);
   }
 };
 

--- a/test/server.js
+++ b/test/server.js
@@ -18,7 +18,7 @@ var validate = function (decoded, request, callback) {
     return callback(null, true);
   }
   else {
-    return callback('fail', false);
+    return callback(null, false);
   }
 };
 

--- a/test/validate-func-test.js
+++ b/test/validate-func-test.js
@@ -1,0 +1,42 @@
+var test   = require('tape');
+var Hapi   = require('hapi');
+var Boom   = require('boom');
+var JWT    = require('jsonwebtoken');
+var secret = 'NeverShareYourSecret';
+
+test('Should respond with 500 series error when validateFunc errs', function (t) {
+  t.plan(2);
+
+  var server = new Hapi.Server();
+  server.connection();
+
+  server.register(require('../'), function (err) {
+    t.ifError(err, 'No error registering hapi-auth-jwt2 plugin');
+
+    server.auth.strategy('jwt', 'jwt', {
+      key: secret,
+      validateFunc: function (decoded, request, callback) {
+        return callback(new Error('ASPLODE'));
+      },
+      verifyOptions: {algorithms: ['HS256']}
+    });
+
+    server.route({
+      method: 'POST',
+      path: '/privado',
+      handler: function (req, reply) { return reply('PRIVADO'); },
+      config: { auth: 'jwt' }
+    });
+
+    var options = {
+      method: 'POST',
+      url: '/privado',
+      headers: {Authorization: JWT.sign({id: 138, name: 'Test'}, secret)}
+    };
+
+    server.inject(options, function (response) {
+      t.equal(response.statusCode, 500, 'Server returned 500 for validateFunc error');
+      t.end();
+    });
+  });
+});


### PR DESCRIPTION
`validateFunc` is for validating whether the token contents are valid. When this is successfully determined your code should call the callback passed to it with the result `true` or `false`.

If a server error occurs during the process then your code should call the callback passing the error. Previously hapi-auth-jwt2 would then send back a 401 to the client, even though a server error had occurred.

This PR changes the previous behaviour to now respond with a 500 series error when a server error occurs in the `validateFunc`. This is a breaking change.

See issue #77 for further discussion.