### PR TITLE
resolves #80 remove hoek dependency

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 var Boom      = require('boom'); // error handling https://github.com/hapijs/boom
-var Hoek      = require('hoek'); // hapi utilities https://github.com/hapijs/hoek
+var assert    = require('assert');
 var JWT       = require('jsonwebtoken'); // https://github.com/docdis/learn-json-web-tokens
 var extract   = require('./extract');    // extract token from Auth Header, URL or Coookie
 var pkg       = require('../package.json');
@@ -20,9 +20,9 @@ internals.isFunction = function (functionToCheck) {
 };
 
 internals.implementation = function (server, options) {
-  Hoek.assert(options, 'options are required for jwt auth scheme'); // pre-auth checks
-  Hoek.assert(options.key, 'options must contain secret key or key lookup function'); // no signing key
-  Hoek.assert(typeof options.validateFunc === 'function', 'options.validateFunc must be a valid function');
+  assert(options, 'options are required for jwt auth scheme'); // pre-auth checks
+  assert(options.key, 'options must contain secret key or key lookup function'); // no signing key
+  assert(typeof options.validateFunc === 'function', 'options.validateFunc must be a valid function');
 
   return {
     authenticate: function (request, reply) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "boom": "^2.8.0",
     "cookie": "^0.1.3",
-    "hoek": "^2.14.0",
     "jsonwebtoken": "^5.0.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
As discussed, we don't *need* to use **hoek** for its assert method. one fewer dependency to manage.