### PR TITLE
Update README: `jwt` as default strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,13 @@ server.register(require('hapi-auth-jwt2'), function (err) {
       console.log(err);
     }
 
-    server.auth.strategy('jwt', 'jwt', true,
+    server.auth.strategy('jwt', 'jwt',
     { key: 'NeverShareYourSecret',          // Never Share your secret key
       validateFunc: validate,            // validate function defined above
       verifyOptions: { algorithms: [ 'HS256' ] } // pick a strong algorithm
     });
+    
+    server.auth.default('jwt');
 
     server.route([
       {

--- a/example/server.js
+++ b/example/server.js
@@ -41,10 +41,12 @@ server.register(hapiAuthJWT, function (err) {
     console.log(err);
   }
   // see: http://hapijs.com/api#serverauthschemename-scheme
-  server.auth.strategy('jwt', 'jwt', true,
+  server.auth.strategy('jwt', 'jwt',
   { key: secret,  validateFunc: validate,
     verifyOptions: { ignoreExpiration: true }
   });
+  
+  server.auth.default('jwt');
 
   server.route([
     {

--- a/example/simple_server.js
+++ b/example/simple_server.js
@@ -28,10 +28,12 @@ server.register(require('../lib'), function (err) {
       console.log(err);
     }
 
-    server.auth.strategy('jwt', 'jwt', true,
+    server.auth.strategy('jwt', 'jwt',
     { key: 'NeverShareYourSecret', // Never Share your secret key
       validateFunc: validate       // validate function defined above
     });
+    
+    server.auth.default('jwt');
 
     server.route([
       {


### PR DESCRIPTION
I think we shouldn't use the `mode` parameter of the `auth.strategy` method in the README.
It's more explicit to set the default strategy on a separate line.

I personally tripped on it cause I already had a default strategy set when trying `hapi-auth-jwt2`, and I got an error:
```Error: Cannot set default strategy more than once```

And it took some time to realize it's because of the 3rd parameter of the `auth.strategy` method.

Ref:
http://hapijs.com/api#serverauthstrategyname-scheme-mode-options