### PR TITLE
Drop Peer Dependency for Hapi to 8.x.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,11 @@ Unless you include it via ***relative path*** e.g:
 `var JWT = require('./node_modules/hapi-auth-jwt2/node_modules/jsonwebtoken');`  
 we *recommend* including it in your **package.json** ***explicitly*** as a **dependency** for your project.
 
+### Compatibility
+
+`hapi-auth-jwt2` is compatible with both Hapi `9.x.x` and `8.x.x` however we
+recommend using the latest version of Hapi for security/performance updates.
+
 > *If you have a question*, ***please post an issue/question on GitHub***:
 https://github.com/dwyl/hapi-auth-jwt2/issues
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "jsonwebtoken": "^5.0.5"
   },
   "peerDependencies": {
-    "hapi": ">=9.x.x"
+    "hapi": ">=8.x.x"
   },
   "devDependencies": {
     "aguid": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,6 @@
     "cookie": "^0.2.0",
     "jsonwebtoken": "^5.0.5"
   },
-  "peerDependencies": {
-    "hapi": ">=8.x.x"
-  },
   "devDependencies": {
     "aguid": "^1.0.3",
     "hapi": "^9.0.4",


### PR DESCRIPTION
This allows versions below Hapi 9.0.0 to use `hapi-auth-jwt2` due to a lack of an
[API change in Hapi 9.0.0][1]

[1]: https://github.com/hapijs/hapi/issues/2682