### PR TITLE
update dependencies to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status](https://travis-ci.org/dwyl/hapi-auth-jwt2.svg "Build Status = Tests Passing")](https://travis-ci.org/dwyl/hapi-auth-jwt2)
 [![Test Coverage](https://codeclimate.com/github/dwyl/hapi-auth-jwt2/badges/coverage.svg "All Lines Tested")](https://codeclimate.com/github/dwyl/hapi-auth-jwt2)
 [![Code Climate](https://codeclimate.com/github/dwyl/hapi-auth-jwt2/badges/gpa.svg "No Nasty Code")](https://codeclimate.com/github/dwyl/hapi-auth-jwt2)
-[![HAPI 10.0.0](http://img.shields.io/badge/hapi-10.0.0-brightgreen.svg "Latest Hapi.js")](http://hapijs.com)
+[![HAPI 10.4.1](http://img.shields.io/badge/hapi-10.4.1-brightgreen.svg "Latest Hapi.js")](http://hapijs.com)
 [![Node.js Version](https://img.shields.io/node/v/hapi-auth-jwt2.svg?style=flat "Node.js 10 & 12 and io.js latest both supported")](http://nodejs.org/download/)
 [![npm](https://img.shields.io/npm/v/hapi-auth-jwt2.svg)](https://www.npmjs.com/package/hapi-auth-jwt2)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-auth-jwt2",
-  "version": "5.0.6",
+  "version": "5.1.0",
   "description": "Hapi.js Authentication Plugin/Scheme using JSON Web Tokens (JWT)",
   "main": "lib/index.js",
   "repository": {
@@ -31,19 +31,19 @@
   },
   "homepage": "https://github.com/dwyl/hapi-auth-jwt2",
   "dependencies": {
-    "boom": "^2.8.0",
-    "cookie": "^0.2.0",
-    "jsonwebtoken": "^5.0.5"
+    "boom": "^2.9.0",
+    "cookie": "^0.2.2",
+    "jsonwebtoken": "^5.4.0"
   },
   "devDependencies": {
     "aguid": "^1.0.3",
-    "hapi": "^10.0.0",
-    "codeclimate-test-reporter": "^0.1.0",
-    "istanbul": "^0.3.19",
+    "hapi": "^10.4.1",
+    "codeclimate-test-reporter": "^0.1.1",
+    "istanbul": "^0.3.22",
     "jshint": "^2.8.0",
     "pre-commit": "^1.1.1",
     "tap-spec": "^4.1.0",
-    "tape": "^4.2.0"
+    "tape": "^4.2.1"
   },
   "engines": {
     "node": ">=4.0"


### PR DESCRIPTION
Release for **Allow additional strategies to authenticate if no token is found**
See/fixes: https://github.com/dwyl/hapi-auth-jwt2/issues/104