### PR TITLE
support try mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ internals.implementation = function (server, options) {
     authenticate: function (request, reply) {
       var token = extract(request, options);
 
-      if (!token && request.auth.mode === 'optional') {
+      if (!token && request.auth.mode !== 'required') {
         return reply.continue({ credentials: {} });
       }
 


### PR DESCRIPTION
As per https://github.com/hapijs/hapi/blob/master/API.md#route-options, the `"try"` auth mode should act the same as optional.

I switched the check to `!== 'required'` because there are only 3 supported options.