### PR TITLE
Updates version of hapi to 11.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status](https://travis-ci.org/dwyl/hapi-auth-jwt2.svg "Build Status = Tests Passing")](https://travis-ci.org/dwyl/hapi-auth-jwt2)
 [![Test Coverage](https://codeclimate.com/github/dwyl/hapi-auth-jwt2/badges/coverage.svg "All Lines Tested")](https://codeclimate.com/github/dwyl/hapi-auth-jwt2)
 [![Code Climate](https://codeclimate.com/github/dwyl/hapi-auth-jwt2/badges/gpa.svg "No Nasty Code")](https://codeclimate.com/github/dwyl/hapi-auth-jwt2)
-[![HAPI 10.4.1](http://img.shields.io/badge/hapi-10.4.1-brightgreen.svg "Latest Hapi.js")](http://hapijs.com)
+[![HAPI 11.0.0](http://img.shields.io/badge/hapi-11.0.0-brightgreen.svg "Latest Hapi.js")](http://hapijs.com)
 [![Node.js Version](https://img.shields.io/node/v/hapi-auth-jwt2.svg?style=flat "Node.js 10 & 12 and io.js latest both supported")](http://nodejs.org/download/)
 [![npm](https://img.shields.io/npm/v/hapi-auth-jwt2.svg)](https://www.npmjs.com/package/hapi-auth-jwt2)
 
@@ -304,7 +304,7 @@ we *recommend* including it in your **package.json** ***explicitly*** as a **dep
 
 ### Compatibility
 
-`hapi-auth-jwt2` is compatible with Hapi.js versions `10.x.x` `9.x.x` and `8.x.x` as there was no change to how the Hapi plugin system works
+`hapi-auth-jwt2` is compatible with Hapi.js versions `11.x.x` `10.x.x` `9.x.x` and `8.x.x` as there was no change to how the Hapi plugin system works
 for the past two versions.
 See the release notes for more details:
 + Hapi Version 10: https://github.com/hapijs/hapi/issues/2764

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-auth-jwt2",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "Hapi.js Authentication Plugin/Scheme using JSON Web Tokens (JWT)",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "aguid": "^1.0.3",
-    "hapi": "^10.4.1",
+    "hapi": "^11.0.0",
     "codeclimate-test-reporter": "^0.1.1",
     "istanbul": "^0.3.22",
     "jshint": "^2.8.0",


### PR DESCRIPTION
Updates the devdependency to [hapi v11.0.0](https://github.com/hapijs/hapi/issues/2850), including readme update and a _patch_ version bump to the package version according to [semver](http://semver.org/).

@nelsonic Please review :+1: Fixes #114 