### PR TITLE
Adding the option to use the 'response' attirbute of server.auth.scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ signature `function(decoded, callback)` where:
     - `audience` - do not enforce token [*audience*](http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#audDef)
     - `issuer` - do not require the issuer to be valid
     - `algorithms` - list of allowed algorithms
+- `responseFunc` - (***optional***) optional function called to decorate the response with authentication headers before the response headers or payload is written where:
+    - `request` - the request object.
+    - `reply(err, response)`- is called if an error occurred
 - `urlKey` - (***optional***) if you prefer to pass your token via url, simply add a `token` url parameter to your request or use a custom parameter by setting `urlKey`
 - `cookieKey` - (***optional***) if you prefer to pass your token via a cookie, simply set the cookie `token=your.jsonwebtoken.here` or use a custom key by setting `cookieKey`
 - `tokenType` - (**optinal**) allow custom token type, e.g. Authorization: \<tokenType> 12345678, default is none.

--- a/lib/index.js
+++ b/lib/index.js
@@ -95,6 +95,21 @@ internals.implementation = function (server, options) {
       // else { // warn the person that the plugin requires either a validateFunc or verifyFunc!
       //   return reply(Boom.notImplemented('please specify a hapi-auth-jwt2 validateFunc or verifyFunc.', 'Token'), null, { credentials: decoded });
       // }
+    },
+    response: function(request, reply) {
+      if(options.responseFunc && typeof options.responseFunc === 'function') {
+        options.responseFunc(request, reply, function(err) {
+          if (err) {
+            return reply(Boom.wrap(err));
+          }
+          else {
+            reply.continue();
+          }
+        })
+      }
+      else {
+        reply.continue();
+      }
     }
   };
 };

--- a/test/scheme-response-server.js
+++ b/test/scheme-response-server.js
@@ -1,0 +1,97 @@
+var Hapi   = require('hapi');
+var secret = 'NeverShareYourSecret';
+
+// for debug options see: http://hapijs.com/tutorials/logging
+var server = new Hapi.Server({ debug: false });
+server.connection();
+
+var db = {
+    "123": { allowed: true,  "name": "Charlie"  },
+    "321": { allowed: false, "name": "Old Gregg"}
+};
+
+// defining our own validate function lets us do something
+// useful/custom with the decodedToken before reply(ing)
+var validate = function (decoded, request, callback) {
+    if (db[decoded.id].allowed) {
+        return callback(null, true);
+    }
+    else {
+        return callback(null, false);
+    }
+};
+
+var home = function(req, reply) {
+    return reply('Hai!');
+};
+
+var privado = function(req, reply) {
+    return reply('worked');
+};
+
+var sendToken = function(req, reply) {
+    return reply(req.auth.token);
+};
+
+var responseFunction = function(req, reply, callback) {
+    var error = null;
+    if(req.headers.error === 'true') {
+        error = new Error('failed');
+    } else {
+        req.response.header('Authorization', 'from scheme response function');
+    }
+    callback(error); //no error
+}
+
+server.register(require('../'), function () {
+
+    server.auth.strategy('jwt', 'jwt', {
+        key: secret,
+        validateFunc: validate,
+        verifyOptions: {
+            algorithms: [ 'HS256' ]
+        }, // only allow HS256 algorithm
+        responseFunc: responseFunction
+    });
+
+    server.route([
+        {
+            method: 'GET',
+            path: '/',
+            handler: home,
+            config: {
+                auth: false
+            }
+        },
+        {
+            method: 'GET',
+            path: '/token',
+            handler: sendToken,
+            config: {
+                auth: 'jwt'
+            }
+        },
+        {
+            method: 'POST',
+            path: '/privado',
+            handler: privado,
+            config: {
+                auth: 'jwt'
+            }
+        },
+        {
+            method: 'POST',
+            path: '/required',
+            handler: privado,
+            config: {
+                auth: {
+                    mode: 'required',
+                    strategy: 'jwt'
+                }
+            }
+        }
+    ]);
+
+});
+
+module.exports = server;

--- a/test/scheme-response-test.js
+++ b/test/scheme-response-test.js
@@ -1,0 +1,129 @@
+var test   = require('tape');
+var JWT    = require('jsonwebtoken');
+var secret = 'NeverShareYourSecret';
+
+var server = require('./scheme-response-server'); // test server which in turn loads our module
+
+test("Warm Up the Engine", function(t) {
+  var options = {
+    method: "GET",
+    url: "/"
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 200, "Unrestricted endpoint will work without issues");
+    t.equal(response.headers.authorization, undefined, 'Endpoints that do not call the authorization scheme should not be called');
+    t.end();
+  });
+});
+
+test("Attempt to access restricted content (without auth token)", function(t) {
+  var options = {
+    method: "POST",
+    url: "/privado"
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 401, "No Token should fail");
+    t.equal(response.headers.authorization, undefined, 'Invalid requests should not be calling the response function');
+    t.end();
+  });
+});
+
+
+test("Attempt to access restricted content (with an INVALID Token)", function(t) {
+  var options = {
+    method: "POST",
+    url: "/privado",
+    headers: { authorization: "Bearer fails.validation" }
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 401, "INVALID Token should fail");
+    t.equal(response.headers.authorization, undefined, 'Invalid requests should not be calling the response function');
+    t.end();
+  });
+});
+
+
+test("Access restricted content (with VALID Token)", function(t) {
+  // use the token as the 'authorization' header in requests
+  var token = JWT.sign({ id: 123, "name": "Charlie" }, secret);
+  var options = {
+    method: "POST",
+    url: "/privado",
+    headers: { authorization: "Bearer " + token }
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 200, "VALID Token should succeed!");
+    t.equal(response.headers.authorization, 'from scheme response function', 'Valid request should finish by calling response function');
+    t.end();
+  });
+});
+
+
+test("Auth mode 'required' should require authentication header", function(t) {
+  var options = {
+    method: "POST",
+    url: "/required"
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 401, "No token header should fail in auth 'required' mode");
+    t.equal(response.headers.authorization, undefined, 'Invalid requests should not be calling the response function');
+    t.end();
+  });
+});
+
+
+test("Auth mode 'required' should should pass with valid token", function(t) {
+  // use the token as the 'authorization' header in requests
+  var token = JWT.sign({ id: 123, "name": "Charlie" }, secret);
+  var options = {
+    method: "POST",
+    url: "/required",
+    headers: { authorization: "Bearer " + token }
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 200, "Valid token should succeed!");
+    t.equal(response.headers.authorization, 'from scheme response function', 'Valid request should finish by calling response function');
+    t.end();
+  });
+});
+
+
+test("Scheme should set token in request.auth.token", function(t) {
+  // use the token as the 'authorization' header in requests
+  var token = JWT.sign({ id: 123, "name": "Charlie" }, secret);
+  var options = {
+    method: "GET",
+    url: "/token",
+    headers: { authorization: "Bearer " + token }
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    t.equal(response.result, token, 'Token is accesible from handler');
+    t.equal(response.headers.authorization, 'from scheme response function', 'Valid request should finish by calling response function');
+    t.end();
+  });
+});
+
+test("Testing an error thrown from the scheme\'s response function", function(t) {
+  // use the token as the 'authorization' header in requests
+  var token = JWT.sign({ id: 123, "name": "Charlie" }, secret);
+  var options = {
+    method: "GET",
+    url: "/token",
+    headers: {
+        authorization: "Bearer " + token,
+        error: 'true'
+    }
+  };
+  // server.inject lets us similate an http request
+  server.inject(options, function(response) {
+    t.equal(response.statusCode, 500, 'A server error happens in the scheme\'s response function');
+    t.end();
+  });
+});


### PR DESCRIPTION
http://hapijs.com/api#serverauthschemename-scheme

This addition will allow to use the ```hapi-auth-jwt2``` plugin to leverage the ```response``` attribute of the hapi api (see link above).

Using this strategy something like so is now feasible : 
```
...
server.auth.strategy('jwt', 'jwt', true,
{
    key: "sshhhh",
    validateFunc: validate,
    verifyOptions: {
        algorithms: [ 'HS256' ]
    },
    responseFunc: function(request, reply) {
        request.response.header('new-header', 'added here');
    }
});
...
```

