### PR TITLE
Added completeToken option to pass complete token (including header and signature) to callback functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ signature `function(decoded, callback)` where:
     - `reply(err, response)`- is called if an error occurred
 - `urlKey` - (***optional***) if you prefer to pass your token via url, simply add a `token` url parameter to your request or use a custom parameter by setting `urlKey`
 - `cookieKey` - (***optional***) if you prefer to pass your token via a cookie, simply set the cookie `token=your.jsonwebtoken.here` or use a custom key by setting `cookieKey`
-- `tokenType` - (**optinal**) allow custom token type, e.g. Authorization: \<tokenType> 12345678, default is none.
+- `tokenType` - (**optional**) allow custom token type, e.g. Authorization: \<tokenType> 12345678, default is none.
+- `completeToken` - (**optional**) set to `true` to receive the complete token (`decoded.header`, `decoded.payload` and `decoded.signature`) as `decoded` argument to key lookup and verifyFunc callbacks (but not validateFunc)
 
 ### Understanding the Request Flow
 
@@ -234,7 +235,7 @@ This plugin supports [authentication modes](http://hapijs.com/api#route-options)
 
 ### Additional notes on key lookup functions
 
-- This option to look up a secret key was added to support "multi-tenant" environments. One use case would be companies that white label API services for their customers and cannot use a shared secret key.
+- This option to look up a secret key was added to support "multi-tenant" environments. One use case would be companies that white label API services for their customers and cannot use a shared secret key. If the key lookup function needs to use fields from the token header (e.g. [x5t header](http://self-issued.info/docs/draft-jones-json-web-token-01.html#ReservedHeaderParameterName), set option `completeToken` to `true`.
 
 - The reason why you might want to pass back `extraInfo` in the callback is because you likely need to do a database call to get the key which also probably returns useful user data. This could save you another call in `validateFunc`.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,13 @@ internals.implementation = function (server, options) {
       // otherwise use the same key (String) to validate all JWTs
       var decoded;
       try {
-        decoded = JWT.decode(token); // decode is non-io and fast enough to not have to be async
+		if (options.completeToken === true) { 
+			// We want the complete token in decoded.header and decoded.payload
+			decoded = JWT.decode(token, { complete: true }); // decode is non-io and fast enough to not have to be async
+;		} else {
+			// We just want the token payload in decoded
+			decoded = JWT.decode(token); // decode is non-io and fast enough to not have to be async
+		}
       }
       catch(e) { // request should still FAIL if the token does not decode.
         return reply(Boom.unauthorized('Invalid token format', 'Token'));

--- a/test/complete_token_test.js
+++ b/test/complete_token_test.js
@@ -1,0 +1,46 @@
+var test   = require('tape');
+var Hapi   = require('hapi');
+var JWT    = require('jsonwebtoken');
+var secret = 'NeverShareYourSecret';
+
+var keyDict = { 5678: secret };
+
+test('Full token payload (header + payload + signature) is available to key lookup function using completeToken option', function (t) {
+
+  var server = new Hapi.Server();
+  server.connection();
+
+  server.register(require('../'), function (err) {
+    t.ifError(err, 'No error registering hapi-auth-jwt2 plugin');
+
+    server.auth.strategy('jwt', 'jwt', {
+      key: function (decoded, callback) {
+		var signatureKey = keyDict[decoded.header.x5t]; // Look dynamically for key based on JWT header field
+        return callback(null, signatureKey);
+      },
+	  completeToken: true,
+      validateFunc: function (decoded, request, callback) {
+        return callback(null, true);
+      },
+      verifyOptions: {algorithms: ['HS256']}
+    });
+
+    server.route({
+      method: 'POST',
+      path: '/',
+      handler: function (request, reply) { return reply('Ok'); },
+      config: { auth: 'jwt' }
+    });
+
+    var options = {
+      method: 'POST',
+      url: '/',
+      headers: {Authorization: JWT.sign({ id: 1234 }, secret, { headers: { x5t: 5678 } })} // set custom JWT header field "x5t"
+    };
+
+    server.inject(options, function (response) {
+      t.equal(response.statusCode, 200, 'Server returned 200 status');
+      t.end();
+    });
+  });
+});


### PR DESCRIPTION
New `completeToken` option to receive the complete token (decoded.header, decoded.payload and decoded.signature) as decoded argument to key lookup and verifyFunc callbacks (but not validateFunc). This gives additional information to such callbacks functions.

`decoded` will be passed as an object with fields header, payload and signature, instead of just the payload.

See discussion in [Issue 152](https://github.com/dwyl/hapi-auth-jwt2/issues/152)