### PR TITLE
Fix error in verifyFunc docs: verified => unverified

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ while you are initializing the plugin.
 
 - `verifyFunc` - (***optional***) the function which is run once the Token has been decoded
 (*instead of a `validateFunc`*) with signature `function(decoded, request, callback)` where:
-    - `decoded` - (***required***) is the ***decoded*** and ***verified*** JWT received from the client in **request.headers.authorization**
+    - `decoded` - (***required***) is the decoded but ***unverified*** JWT received from the client in `request.headers.authorization`.
     - `request` - (***required***) is the original ***request*** received from the client
     - `callback` - (***required***) a callback function with the signature `function(err, isValid, credentials)` where:
         - `err` - an internal error.

--- a/README.md
+++ b/README.md
@@ -399,8 +399,7 @@ The [*internals*](https://github.com/dwyl/hapi-auth-jwt2/blob/eb9fff9fc384fde07e
 of `hapi-auth-jwt2` use the `jsonwebtoken.verify` method to ***verify*** if the
 JTW was signed using the `JWT_SECRET` (*secret key*).
 
-If you prefer specify your own verification steps instead of having a `validateFunc` simply define a `verifyFunc` ***instead***
-while you are initializing the plugin.
+If you prefer specifying your own verification logic instead of having a `validateFunc`, simply define a `verifyFunc` instead when initializing the plugin.
 
 - `verifyFunc` - (***optional***) the function which is run once the Token has been decoded
 (*instead of a `validateFunc`*) with signature `function(decoded, request, callback)` where:


### PR DESCRIPTION
The most important change here is correcting the error that says `verifyFunc()` receives the verified token. It is of course the *unverified* token.

Also:

* Eliminated some unnecessary emphasis / strong emphasis styling. Styling too much as emphasized or strongly emphasized makes it harder to recognize things that really need it. For example, the fact that the function receives the unverified token is arguably something worthy of strong emphasis.

* Fixed a typo: "prefer specify your" and simplified the language a bit in general. Marked up variable name as code.

This method would be quite a bit more useful if it received the options and JWT library so that you could do something extra but still use `JWT.verify` like the default internal logic without having to figure out a way to get the options to the function or depend on `jsonwebtoken` yourself just to do it. I can see that technically the options would be available as the `this` object, but it's not documented and doesn't get you the JWT library