### PR TITLE
update to latest version of Boom & Hapi - no code change required

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Build Status](https://travis-ci.org/dwyl/hapi-auth-jwt2.svg "Build Status = Tests Passing")](https://travis-ci.org/dwyl/hapi-auth-jwt2)
 [![codecov.io Code Coverage](https://img.shields.io/codecov/c/github/dwyl/hapi-auth-jwt2.svg?maxAge=2592000)](https://codecov.io/github/dwyl/hapi-auth-jwt2?branch=master)
 [![Code Climate](https://codeclimate.com/github/dwyl/hapi-auth-jwt2/badges/gpa.svg "No Nasty Code")](https://codeclimate.com/github/dwyl/hapi-auth-jwt2)
-[![HAPI 14.2.0](http://img.shields.io/badge/hapi-14.2.0-brightgreen.svg "Latest Hapi.js")](http://hapijs.com)
+[![HAPI 15.0.3](http://img.shields.io/badge/hapi-15.0.3-brightgreen.svg "Latest Hapi.js")](http://hapijs.com)
 [![Node.js Version](https://img.shields.io/node/v/hapi-auth-jwt2.svg?style=flat "Node.js 10 & 12 and io.js latest both supported")](http://nodejs.org/download/)
 [![Dependency Status](https://david-dm.org/dwyl/hapi-auth-jwt2.svg "Dependencies Checked & Updated Regularly (Security is Important!)")](https://david-dm.org/dwyl/hapi-auth-jwt2)
 [![devDependencies Status](https://david-dm.org/dwyl/hapi-auth-jwt2/dev-status.svg)](https://david-dm.org/dwyl/hapi-auth-jwt2?type=dev)

--- a/package.json
+++ b/package.json
@@ -39,13 +39,13 @@
   },
   "homepage": "https://github.com/dwyl/hapi-auth-jwt2",
   "dependencies": {
-    "boom": "^3.2.2",
+    "boom": "^4.0.0",
     "cookie": "^0.3.1",
     "jsonwebtoken": "^7.1.9"
   },
   "devDependencies": {
     "aguid": "^1.0.4",
-    "hapi": "^14.2.0",
+    "hapi": "^15.0.3",
     "istanbul": "^0.4.5",
     "jshint": "^2.9.3",
     "pre-commit": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-auth-jwt2",
-  "version": "7.1.2",
+  "version": "7.1.3",
   "description": "Hapi.js Authentication Plugin/Scheme using JSON Web Tokens (JWT)",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
Self-explanatory. Boom updated: https://github.com/hapijs/boom/releases/tag/v4.0.0
(_no clear explanation of what was changed and required a **Major** version Bump ..._)

fixes https://github.com/dwyl/hapi-auth-jwt2/issues/192

Tests all still pass so at least from the perspective of _our_ plugin the API has remained constant. 👍 