### PR TITLE
Update dev dependency on hapi to v16

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![JavaScript Style Guide: Good Parts](https://img.shields.io/badge/code%20style-goodparts-brightgreen.svg?style=flat)](https://github.com/dwyl/goodparts "JavaScript The Good Parts")
 [![Inline docs](http://inch-ci.org/github/dwyl/hapi-auth-jwt2.svg?branch=master)](http://inch-ci.org/github/dwyl/hapi-auth-jwt2)
 [![Code Climate](https://codeclimate.com/github/dwyl/hapi-auth-jwt2/badges/gpa.svg "No Nasty Code")](https://codeclimate.com/github/dwyl/hapi-auth-jwt2)
-[![HAPI 15.2.0](http://img.shields.io/badge/hapi-15.2.0-brightgreen.svg "Latest Hapi.js")](http://hapijs.com)
+[![HAPI 16.0.1](http://img.shields.io/badge/hapi-16.0.1-brightgreen.svg "Latest Hapi.js")](http://hapijs.com)
 [![Node.js Version](https://img.shields.io/node/v/hapi-auth-jwt2.svg?style=flat "Node.js 10 & 12 and io.js latest both supported")](http://nodejs.org/download/)
 [![Dependency Status](https://david-dm.org/dwyl/hapi-auth-jwt2.svg "Dependencies Checked & Updated Regularly (Security is Important!)")](https://david-dm.org/dwyl/hapi-auth-jwt2)
 [![devDependencies Status](https://david-dm.org/dwyl/hapi-auth-jwt2/dev-status.svg)](https://david-dm.org/dwyl/hapi-auth-jwt2?type=dev)
@@ -551,7 +551,8 @@ because with a `verifyFunc` you can incorporate your own custom-logic.
 
 ### Compatibility
 
-`hapi-auth-jwt2` is compatible with Hapi.js versions `14.x.x` `13.x.x` `12.x.x` `11.x.x` `10.x.x` `9.x.x` and `8.x.x`
+`hapi-auth-jwt2` is compatible with Hapi.js versions `16.x.x`
+`15.x.x` `14.x.x` `13.x.x` `12.x.x` `11.x.x` `10.x.x` `9.x.x` and `8.x.x`
 as there have been ***no changes*** to how the Hapi plugin system works for a while!
 
 However in the interest of

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -53,6 +53,5 @@ module.exports = function extract (request, options) {
  * @returns {Boolean} true|false - true if JWT is valid. false if invalid.
  */
 module.exports.isValid = function isValid (token) {
-  
   return token.split('.').length === 3;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-auth-jwt2",
-  "version": "7.2.3",
+  "version": "7.2.4",
   "description": "Hapi.js Authentication Plugin/Scheme using JSON Web Tokens (JWT)",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "aguid": "^1.0.4",
     "goodparts": "^1.2.0",
-    "hapi": "^15.2.0",
+    "hapi": "^16.0.1",
     "istanbul": "^0.4.5",
     "jshint": "^2.9.3",
     "pre-commit": "^1.1.3",


### PR DESCRIPTION
@iteles this update makes no change to code other than to fix a `lint` issue in `lib/extract.js`.
update Hapi to v16 to confirm that the plugin works with the latest version.

Please let me know when you are able to merge this so I can publish a new version to NPM. thanks!