### PR TITLE
Final Hapi v.16 Compatible Release for Existing Apps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - "6.0.0"
+  - "6"
+  - "8"
+  - "9"
 env:
   - JWT_SECRET="EverythingIsAwesome!"
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "4.2.3"
   - "6.0.0"
 env:
   - JWT_SECRET="EverythingIsAwesome!"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://github.com/dwyl/hapi-auth-jwt2",
   "dependencies": {
-    "boom": "^5.1.0",
+    "boom": "^6.0.0",
     "cookie": "^0.3.1",
     "jsonwebtoken": "^8.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-auth-jwt2",
-  "version": "7.3.0",
+  "version": "8.0.0",
   "description": "Hapi.js Authentication Plugin/Scheme using JSON Web Tokens (JWT)",
   "main": "lib/index.js",
   "repository": {
@@ -45,7 +45,7 @@
   "dependencies": {
     "boom": "^5.1.0",
     "cookie": "^0.3.1",
-    "jsonwebtoken": "^7.4.1"
+    "jsonwebtoken": "^8.1.0"
   },
   "devDependencies": {
     "aguid": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "aguid": "^2.0.0",
     "goodparts": "^1.2.1",
-    "hapi": "^16.4.3",
+    "hapi": "^16.6.2",
     "istanbul": "^0.4.5",
     "jshint": "^2.9.4",
     "pre-commit": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-auth-jwt2",
-  "version": "8.0.0",
+  "version": "7.3.0",
   "description": "Hapi.js Authentication Plugin/Scheme using JSON Web Tokens (JWT)",
   "main": "lib/index.js",
   "repository": {
@@ -58,7 +58,7 @@
     "tape": "^4.6.3"
   },
   "engines": {
-    "node": ">=4.2.3"
+    "node": ">=6"
   },
   "scripts": {
     "quick": "./node_modules/tape/bin/tape ./test/*.test.js | node_modules/tap-spec/bin/cmd.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-auth-jwt2",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "Hapi.js Authentication Plugin/Scheme using JSON Web Tokens (JWT)",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
As discussed in: https://github.com/dwyl/hapi-auth-jwt2/issues/255
also fixes #257 (_no longer supporting node.js v4_)