### PR TITLE
Readd promise support to response function

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ signature `async function(decoded)` where:
     - `algorithms` - list of allowed algorithms
 - `responseFunc` - (***optional***) function called to decorate the response with authentication headers before the response headers or payload is written where:
     - `request` - the request object.
-    - `reply(err, response)`- is called if an error occurred
+    - `h`- the response toolkit.
 - `errorFunc` - (***optional*** *defaults to raising the error requested*) function called when an error has been raised. It provides an extension point to allow the host the ability to customise the error messages returned. Passed in object follows the following schema:
     - `errorContext.errorType` - ***required*** the `Boom` method to call (eg. unauthorized)
     - `errorContext.message` - ***required*** the `message` passed into the `Boom` method call

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,16 +31,24 @@ exports.plugin.pkg = pkg; // hapi requires attributes for a plugin.
 
 /**
  * isFunction checks if a given value is a function.
+ * @param {Object} objectToCheck - the object we want to check its type
+ * @returns {String} - returns the string of the object class
+ */
+internals.checkObjectType = function(objectToCheck) {
+  const toString = Object.prototype.toString;
+  return toString.call(objectToCheck);
+};
+
+/**
+ * isFunction checks if a given value is a function.
  * @param {Object} functionToCheck - the object we want to confirm is a function
  * @returns {Boolean} - true if the functionToCheck is a function. :-)
  */
 internals.isFunction = function(functionToCheck) {
-  let getType = {};
-
   return (
     functionToCheck &&
-    (getType.toString.call(functionToCheck) === '[object Function]' ||
-      getType.toString.call(functionToCheck) === '[object AsyncFunction]')
+    (internals.checkObjectType(functionToCheck) === '[object Function]' ||
+      internals.checkObjectType(functionToCheck) === '[object AsyncFunction]')
   );
 };
 
@@ -234,10 +242,18 @@ internals.implementation = function(server, options) {
      * @returns {Boolean} true. always return true (unless there's an error...)
      */
     response: function(request, h) {
-      if (options.responseFunc && typeof options.responseFunc === 'function') {
+      const responseFunc = options.responseFunc;
+      if (responseFunc && typeof responseFunc === 'function') {
+        if (
+          internals.checkObjectType(responseFunc) === '[object AsyncFunction]'
+        ) {
+          return responseFunc(request, h)
+            .then(() => h.continue)
+            .catch(err => raiseError('boomify', err));
+        }
         try {
           // allow responseFunc to decorate or throw
-          options.responseFunc(request, h);
+          responseFunc(request, h);
         } catch (err) {
           throw raiseError('boomify', err);
         }

--- a/test/scheme-response.test.js
+++ b/test/scheme-response.test.js
@@ -107,3 +107,34 @@ test("Testing an error thrown from the scheme\'s response function", async funct
     t.equal(response.statusCode, 500, 'A server error happens in the scheme\'s response function');
     t.end();
 });
+
+test("Access restricted content (with VALID Token) and async response function", async function(t) {
+  // use the token as the 'authorization' header in requests
+  const token = JWT.sign({ id: 123, "name": "Charlie" }, secret);
+  const options = {
+    method: "POST",
+    url: "/async",
+    headers: { authorization: "Bearer " + token }
+  };
+
+  const response = await server.inject(options);
+    t.equal(response.statusCode, 200, "VALID Token should succeed!");
+    t.equal(response.headers.authorization, 'from scheme response function', 'Valid request should finish by calling async response function');
+    t.end();
+});
+
+test("Testing an error thrown from the scheme\'s async response function", async function(t) {
+  // use the token as the 'authorization' header in requests
+  const token = JWT.sign({ id: 123, "name": "Charlie" }, secret);
+  const options = {
+    method: "POST",
+    url: "/async",
+    headers: {
+        authorization: "Bearer " + token,
+        error: 'true'
+    }
+  };
+  const response = await server.inject(options);
+    t.equal(response.statusCode, 500, 'A server error happens in the scheme\'s response function');
+    t.end();
+});


### PR DESCRIPTION
This PR addresses https://github.com/dwyl/hapi-auth-jwt2/issues/271.

I tried to detect if a function is async by reusing some of the methods in the existing library and I changed the detect object type as recommended by [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString).

I also tried to avoid making the `response` property an async function to allow other functions that are not async to be run without being awaited on. Perhaps, we could use the same `asyncFunction` check and only await on async functions, so that we could make the `response` property an async function without affecting performance.

Open to suggestions on what best would work!