### PR TITLE
Verify the token is still valid in a long running request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - "8.9.0"
-  - "9"
+  - "8"
+  - "10"
+  - "11"
   - "node"
 env:
   - JWT_SECRET="EverythingIsAwesome!"

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,10 +63,9 @@ internals.getKeys = async function(decoded, options) {
 
 internals.verifyJwt = function(token, keys, options) {
   let error;
-  let verifyOptions = options.verifyOptions || {};
   for (const k of keys) {
     try {
-      return JWT.verify(token, k, verifyOptions);
+      return JWT.verify(token, k, options.verifyOptions);
     } catch (verify_err) {
       error = verify_err;
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -270,5 +270,14 @@ internals.implementation = function(server, options) {
       }
       return h.continue;
     },
+
+    verify: async function(auth) {
+      const token = auth.artifacts;
+      const decoded = JWT.decode(token, {
+        complete: options.complete || false,
+      });
+      const { keys } = await internals.getKeys(decoded, options);
+      internals.verifyJwt(token, keys, options);
+    },
   };
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,6 +52,28 @@ internals.isFunction = function(functionToCheck) {
   );
 };
 
+internals.getKeys = async function(decoded, options) {
+  // if keyFunc is function allow dynamic key lookup: https://git.io/vXjvY
+  const { key, ...extraInfo } = internals.isFunction(options.key)
+    ? await options.key(decoded)
+    : { key: options.key };
+  const keys = Array.isArray(key) ? key : [key];
+  return { keys, extraInfo };
+};
+
+internals.verifyJwt = function(token, keys, options) {
+  let error;
+  let verifyOptions = options.verifyOptions || {};
+  for (const k of keys) {
+    try {
+      return JWT.verify(token, k, verifyOptions);
+    } catch (verify_err) {
+      error = verify_err;
+    }
+  }
+  throw error;
+};
+
 /**
  * implementation is the "main" interface to the plugin and contains all the
  * "implementation details" (methods) such as authenicate, response & raiseError
@@ -146,69 +168,57 @@ internals.implementation = function(server, options) {
           { credentials: token }
         );
       }
-      const { key, ...extraInfo } = internals.isFunction(options.key)
-        ? await options.key(decoded)
-        : { key: options.key };
-      // if keyFunc is function allow dynamic key lookup: https://git.io/vXjvY
+
       if (typeof options.validate === 'function') {
-        let verifyOptions = options.verifyOptions || {};
-        let keys = Array.isArray(key) ? key : [key];
+        const { keys, extraInfo } = await internals.getKeys(decoded, options);
 
         /* istanbul ignore else */
         if (extraInfo) {
           request.plugins[pkg.name] = { extraInfo };
         }
 
-        let k;
-        for (let i = 0; i < keys.length; ++i) {
-          k = keys[i];
-          let verify_decoded;
-          try {
-            verify_decoded = JWT.verify(token, k, verifyOptions);
-          } catch (verify_err) {
-            if (i >= keys.length - 1) {
-              // we have exhausted all keys and still fail
-              let err_message =
-                verify_err.message === 'jwt expired'
-                  ? 'Expired token'
-                  : 'Invalid token';
-              return h.unauthenticated(
-                raiseError('unauthorized', err_message, tokenType),
-                { credentials: token }
-              );
-            }
-            // verification failed but there are still keys to try
-            continue;
+        let verify_decoded;
+        try {
+          verify_decoded = internals.verifyJwt(token, keys, options);
+        } catch (verify_err) {
+          let err_message =
+            verify_err.message === 'jwt expired'
+              ? 'Expired token'
+              : 'Invalid token';
+          return h.unauthenticated(
+            raiseError('unauthorized', err_message, tokenType),
+            { credentials: token }
+          );
+        }
+
+        try {
+          let { isValid, credentials, response } = await options.validate(
+            verify_decoded,
+            request,
+            h
+          );
+          if (response !== undefined) {
+            return h.response(response).takeover();
           }
-          try {
-            let { isValid, credentials, response } = await options.validate(
-              verify_decoded,
-              request,
-              h
+          if (!isValid) {
+            // invalid credentials
+            return h.unauthenticated(
+              raiseError('unauthorized', 'Invalid credentials', tokenType),
+              { credentials: decoded }
             );
-            if (response !== undefined) {
-              return h.response(response).takeover();
-            }
-            if (!isValid) {
-              // invalid credentials
-              return h.unauthenticated(
-                raiseError('unauthorized', 'Invalid credentials', tokenType),
-                { credentials: decoded }
-              );
-            }
-            // valid key and credentials
-            return h.authenticated({
-              credentials:
-                credentials && typeof credentials === 'object'
-                  ? credentials
-                  : decoded,
-              artifacts: token,
-            });
-          } catch (validate_err) {
-            return h.unauthenticated(raiseError('boomify', validate_err), {
-              credentials: decoded,
-            });
           }
+          // valid key and credentials
+          return h.authenticated({
+            credentials:
+              credentials && typeof credentials === 'object'
+                ? credentials
+                : decoded,
+            artifacts: token,
+          });
+        } catch (validate_err) {
+          return h.unauthenticated(raiseError('boomify', validate_err), {
+            credentials: decoded,
+          });
         }
       }
       // see: https://github.com/dwyl/hapi-auth-jwt2/issues/130

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -102,6 +102,36 @@ test("Try using an expired token", async function(t) {
   }, 1100);
 });
 
+test("Token expires while request is taking place", async function(t) {
+  // use the token as the 'authorization' header in requests
+  const token = JWT.sign({ id: 123, "name": "Charlie" }, secret, { expiresIn: '1s' });
+  const options = {
+    method: "POST",
+    url: "/long-running",
+    headers: { authorization: "Bearer " + token  }
+  };
+
+  const response = await server.inject(options);
+  t.equal(response.statusCode, 200);
+  t.equal(response.result, 'Verification failed because token expired');
+  t.end();
+});
+
+test("Token expires after request hass taken place", async function(t) {
+  // use the token as the 'authorization' header in requests
+  const token = JWT.sign({ id: 123, "name": "Charlie" }, secret, { expiresIn: '10s' });
+  const options = {
+    method: "POST",
+    url: "/long-running",
+    headers: { authorization: "Bearer " + token  }
+  };
+
+  const response = await server.inject(options);
+  t.equal(response.statusCode, 200);
+  t.equal(response.result, 'Verification passed');
+  t.end();
+});
+
 test("Token is well formed but is allowed=false so should be denied", async function(t) {
   // use the token as the 'authorization' header in requests
   // const token = jwt.sign({ "id": 1 ,"name":"Old Greg" }, 'incorrectSecret');

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -117,7 +117,7 @@ test("Token expires while request is taking place", async function(t) {
   t.end();
 });
 
-test("Token expires after request hass taken place", async function(t) {
+test("Token expires after request has taken place", async function(t) {
   // use the token as the 'authorization' header in requests
   const token = JWT.sign({ id: 123, "name": "Charlie" }, secret, { expiresIn: '10s' });
   const options = {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -86,8 +86,8 @@ test("Try using an incorrect secret to sign the JWT", async function(t) {
 test("Try using an expired token", async function(t) {
   // use the token as the 'authorization' header in requests
   const token = JWT.sign({ id: 123, "name": "Charlie" }, secret, { expiresIn: '1s' });
-  console.log(" - - - - - - token  - - - - -")
-  console.log(token);
+  // console.log(" - - - - - - token  - - - - -")
+  // console.log(token);
   const options = {
     method: "POST",
     url: "/privado",
@@ -233,7 +233,7 @@ test("Auth mode 'required' should should pass with valid token", async function(
   // server.inject lets us simulate an http request
   const response = await server.inject(options);
   // console.log(" - - - - RESPONSE: ")
-  console.log(response.result);
+  // console.log(response.result);
   t.equal(response.statusCode, 200, "Valid token should succeed!");
   t.end();
 });

--- a/test/basic_server.js
+++ b/test/basic_server.js
@@ -114,7 +114,7 @@ const init = async () =>{
 init();
 
 process.on('unhandledRejection', function(reason, p){
-  console.log("Possibly Unhandled Rejection at: Promise ", p, " reason: ", reason);
+  console.error("Possibly Unhandled Rejection at: Promise ", p, " reason: ", reason);
   // application specific logging here
 });
 

--- a/test/cookies.test.js
+++ b/test/cookies.test.js
@@ -20,7 +20,7 @@ test("Attempt to access restricted content using inVALID Cookie Token", async fu
     url: "/privado",
     headers: { cookie: "token=" + token }
   };
-  console.log(options);
+  // console.log(options);
   const response = await server.inject(options);
   t.equal(response.statusCode, 401, "Invalid token should error!");
   t.end();

--- a/test/custom_parameters.test.js
+++ b/test/custom_parameters.test.js
@@ -13,9 +13,9 @@ test("Attempt to access restricted content using inVALID Cookie Token - custom p
     url: "/privado",
     headers: { cookie: "customCookieKey=" + token }
   };
-  console.log(options);
+  // console.log(options);
   const response = await server.inject(options);
-  console.log('response', response);
+  // console.log('response', response);
     t.equal(response.statusCode, 401, "Invalid token should error!");
     t.end();
 });

--- a/test/dynamic_header_key.test.js
+++ b/test/dynamic_header_key.test.js
@@ -15,7 +15,7 @@ test('When using a custom header key full token payload (header + payload + sign
   }
   server.auth.strategy('jwt', 'jwt', {
     key: function (decoded) {
-      console.log('decoded', keyDict[decoded.header.x5t]);
+      // console.log('decoded', keyDict[decoded.header.x5t]);
       return {key: keyDict[decoded.header.x5t]}; // Look dynamically for key based on JWT header field
     },
     complete: true,
@@ -24,7 +24,7 @@ test('When using a custom header key full token payload (header + payload + sign
     },
     verifyOptions: {algorithms: ['HS256']},
     headerKey: 'auths'
-    
+
   });
   server.route({
     method: 'POST',

--- a/test/dynamic_key.test.js
+++ b/test/dynamic_key.test.js
@@ -13,8 +13,8 @@ test("Access restricted content with a valid token and tenant", async function(t
   };
   // server.inject lets us simulate an http request
   const response = await server.inject(options);
-    console.log(" - - - - RESPONSE: ");
-    console.log(response.result);
+    // console.log(" - - - - RESPONSE: ");
+    // console.log(response.result);
     t.equal(response.statusCode, 200, "VALID Token should succeed!");
     t.equal(response.result.data.additional, 'something extra here if needed', 'extraInfo should be passed through');
 
@@ -31,8 +31,8 @@ test("Access restricted content with an invalid token and tenant", async functio
   };
   // server.inject lets us simulate an http request
   const response = await server.inject(options);
-    console.log(" - - - - RESPONSE: ");
-    console.log(response.result);
+    // console.log(" - - - - RESPONSE: ");
+    // console.log(response.result);
     t.equal(response.statusCode, 401, "INVALID Token should fail!");
 
     t.end();
@@ -48,8 +48,8 @@ test("Access restricted content with a valid token and tenant but user is not al
   };
   // server.inject lets us simulate an http request
   const response = await server.inject(options);
-    console.log(" - - - - RESPONSE: ");
-    console.log(response.result);
+    // console.log(" - - - - RESPONSE: ");
+    // console.log(response.result);
     t.equal(response.statusCode, 401, "Not allowed user should fail!");
 
     t.end();
@@ -65,8 +65,8 @@ test("Access restricted content without tenant specified in token", async functi
   };
   // server.inject lets us simulate an http request
   const response = await server.inject(options);
-    console.log(" - - - - RESPONSE1: ");
-    console.log(response.result);
+    // console.log(" - - - - RESPONSE1: ");
+    // console.log(response.result);
     t.equal(response.statusCode, 400, "No tenant specified should fail!");
 
     t.end();
@@ -82,8 +82,8 @@ test("Access restricted content with non-existent tenant specified", async funct
   };
   // server.inject lets us simulate an http request
   const response = await server.inject(options);
-    console.log(" - - - - RESPONSE: ");
-    console.log(response.result);
+    // console.log(" - - - - RESPONSE: ");
+    // console.log(response.result);
     t.equal(response.statusCode, 401, "No tentant found should fail!");
 
     t.end();

--- a/test/scopes.test.js
+++ b/test/scopes.test.js
@@ -14,8 +14,8 @@ test("Access restricted content using scopes (with VALID Token and VALID scope)"
   };
   // server.inject lets us simulate an http request
   const response = await server.inject(options);
-    console.log(" - - - - RESPONSE: ");
-    console.log(response.result);
+    // console.log(" - - - - RESPONSE: ");
+    // console.log(response.result);
     t.equal(response.statusCode, 200, "VALID Token should succeed!");
 
     t.end();
@@ -31,8 +31,8 @@ test("Access restricted content using scopes (with VALID Token and INVALID scope
   };
   // server.inject lets us simulate an http request
   const response = await server.inject(options);
-    console.log(" - - - - RESPONSE: ");
-    console.log(response.result);
+    // console.log(" - - - - RESPONSE: ");
+    // console.log(response.result);
     t.equal(response.statusCode, 401, "Denied");
     t.end();
 });


### PR DESCRIPTION
Implements a new hapi feature: "async verify(auth) - (optional) a method used to verify the authentication credentials provided are still valid (e.g. not expired or revoked after the initial authentication) where:"

Ideally this would also call something on the `options` to check that the user itself is still valid, not just the token, but that probably needs more though and could result in breaking changes - it can be added later, as the need arises. There is an existing `options.verify()` method, which bypasses all JWT verification, and there is an existing `options.validate()`, but it takes a `request` and `h` as params as well as the decoded token.