### PR TITLE
The async `key` method can throw errors which weren't being caught.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -146,9 +146,32 @@ internals.implementation = function(server, options) {
           { credentials: token }
         );
       }
-      const { key, ...extraInfo } = internals.isFunction(options.key)
-        ? await options.key(decoded)
-        : { key: options.key };
+
+      // Try and call the `key` function asynchronously if it is one
+      let key, extraInfo;
+      if (internals.isFunction(options.key)) {
+        try {
+          const result = await options.key(decoded);
+
+          key = result.key;
+
+          const extraKeys = Object.keys(result).filter(
+            field => field !== 'key'
+          );
+
+          if (extraKeys.length > 0) {
+            extraInfo = {};
+            extraKeys.forEach(field => {
+              extraInfo[field] = result[field];
+            });
+          }
+        } catch (e) {
+          key = options.key;
+        }
+      } else {
+        key = options.key;
+      }
+
       // if keyFunc is function allow dynamic key lookup: https://git.io/vXjvY
       if (typeof options.validate === 'function') {
         let verifyOptions = options.verifyOptions || {};


### PR DESCRIPTION
An example is `hapiJwt2KeyAsync()` from the `node-jwks-rsa` module.

When an invalid JWT token is given (i.e. a.a.a), the existing `await options.key(decoded)` throws an uncaught exception.