### PR TITLE
Support for hapi v18

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,6 +30,13 @@ exports.plugin.pkg = pkg; // hapi requires attributes for a plugin.
 // also see: http://hapijs.com/tutorials/plugins
 
 /**
+ * specify peer dependency on hapi, enforced by hapi at runtime
+ */
+exports.plugin.requirements = {
+  hapi: '>=17',
+};
+
+/**
  * checkObjectType returns the class of the object's prototype
  * @param {Object} objectToCheck - the object for which we want to check the type
  * @returns {String} - the string of the object class

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "aguid": "^2.0.0",
     "eslint": "^5.9.0",
     "eslint-plugin-prettier": "^3.0.0",
-    "hapi": "^17.8.1",
+    "hapi": "^18.0.0",
     "nyc": "^13.1.0",
     "pre-commit": "^1.2.2",
     "prettier": "^1.15.2",


### PR DESCRIPTION
This tests the library on hapi v18 ([release notes](https://github.com/hapijs/hapi/issues/3871)) and adds hapi's new plugin `requirements` to express the peer dependency on hapi in a way that can be enforced at runtime (see https://github.com/hapijs/hapi/issues/3867).