### PR TITLE
Support custom error messages from validate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ signature `async function(decoded)` where:
         - `isValid` - `true` if the JWT was valid, otherwise `false`.
         - `credentials` - (***optional***) alternative credentials to be set instead of `decoded`.
         - `response` - (***optional***) If provided will be used immediately as a takeover response.
+        - `errorMessage` - (***optional*** *defaults to* `'Invalid credentials'`) - the error message raised to Boom if the token is invalid (passed to `errorFunc` as `errorContext.message`)
 
 ### *Optional* Parameters
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -193,18 +193,23 @@ internals.implementation = function(server, options) {
         }
 
         try {
-          let { isValid, credentials, response } = await options.validate(
-            verify_decoded,
-            request,
-            h
-          );
+          let {
+            isValid,
+            credentials,
+            response,
+            errorMessage,
+          } = await options.validate(verify_decoded, request, h);
           if (response !== undefined) {
             return h.response(response).takeover();
           }
           if (!isValid) {
             // invalid credentials
             return h.unauthenticated(
-              raiseError('unauthorized', 'Invalid credentials', tokenType),
+              raiseError(
+                'unauthorized',
+                errorMessage || 'Invalid credentials',
+                tokenType
+              ),
               { credentials: decoded }
             );
           }

--- a/test/validate_func.test.js
+++ b/test/validate_func.test.js
@@ -17,6 +17,12 @@ test('Should respond with 500 series error when validate errs', async function (
         if (decoded.id === 138) {
           throw new Error('ASPLODE');
         }
+        if (decoded.id === 139) {
+          return { isValid: false }
+        }
+        if (decoded.id === 140) {
+          return { isValid: false, errorMessage: 'Bad ID' }
+        }
         return { response:  h.redirect('https://dwyl.com') }
       },
       verifyOptions: {algorithms: ['HS256']}
@@ -42,6 +48,15 @@ test('Should respond with 500 series error when validate errs', async function (
     response = await server.inject(options);
       t.equal(response.statusCode, 302, 'Server redirect status code');
       t.equal(response.headers.location, 'https://dwyl.com', 'Server redirect header');
+      
+    options.headers.Authorization = JWT.sign({id: 139, name: 'Test'}, secret);
+    response = await server.inject(options);
+      t.equal(response.statusCode, 401, 'Server errors when isValid false');
+      t.equal(response.result.message, 'Invalid credentials', 'Default error message when custom not provided');
+
+    options.headers.Authorization = JWT.sign({id: 140, name: 'Test'}, secret);
+    response = await server.inject(options);
+      t.equal(response.result.message, 'Bad ID', 'Custom error message when provided');
       t.end();
 
 });


### PR DESCRIPTION
### Issue: #303 

### Motivation:

Our usage of `hapi-auth-jwt2` includes a validate function with multiple invalid cases (the user is deleted, the user is using an old token etc). We'd like to distinguish between these cases when an error is raised, so we need a custom error, rather than just `Invalid credentials` for all cases.

### In this PR:

- Added an optional `errorMessage` property to the object returned from the `validate` function, defaulting to `Invalid credentials`.
- Update tests to include cases for default and custom errors
- Add a line to the documentation explaining the change