### PR TITLE
fix: update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This basic usage example should help you get started:
 
 
 ```javascript
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const people = { // our "users database"
     1: {

--- a/example/server.js
+++ b/example/server.js
@@ -1,4 +1,4 @@
-const Hapi        = require('hapi');
+const Hapi        = require('@hapi/hapi');
 const hapiAuthJWT = require('../lib/');
 const JWT         = require('jsonwebtoken');  // used to sign our content
 const port        = process.env.PORT || 8000; // allow port to be set

--- a/example/simple_server.js
+++ b/example/simple_server.js
@@ -1,4 +1,4 @@
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const people = { // our "users database"
     1: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Boom = require('boom'); // error handling https://github.com/hapijs/boom
+const Boom = require('@hapi/boom'); // error handling https://github.com/hapijs/boom
 const assert = require('assert'); // use assert to check if options are set
 const JWT = require('jsonwebtoken'); // https://github.com/docdis/learn-json-web-tokens
 const extract = require('./extract'); // extract token from Auth Header, URL or Coookie

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "homepage": "https://github.com/dwyl/hapi-auth-jwt2",
   "dependencies": {
-    "boom": "^7.1.1",
+    "@hapi/boom": "^7.4.2",
     "cookie": "^0.3.1",
     "jsonwebtoken": "^8.1.0"
   },
@@ -55,7 +55,7 @@
     "aguid": "^2.0.0",
     "eslint": "^5.9.0",
     "eslint-plugin-prettier": "^3.0.0",
-    "hapi": "^18.0.0",
+    "@hapi/hapi": "^18.0.0",
     "nyc": "^13.1.0",
     "pre-commit": "^1.2.2",
     "prettier": "^1.15.2",

--- a/test/basic_server.js
+++ b/test/basic_server.js
@@ -1,4 +1,4 @@
-const Hapi   = require('hapi');
+const Hapi   = require('@hapi/hapi');
 const secret = 'NeverShareYourSecret';
 
 // for debug options see: http://hapijs.com/tutorials/logging

--- a/test/complete_token.test.js
+++ b/test/complete_token.test.js
@@ -1,5 +1,5 @@
 const test   = require('tape');
-const Hapi   = require('hapi');
+const Hapi   = require('@hapi/hapi');
 const JWT    = require('jsonwebtoken');
 const secret = 'NeverShareYourSecret';
 

--- a/test/custom_parameters_server.js
+++ b/test/custom_parameters_server.js
@@ -1,4 +1,4 @@
-const Hapi   = require('hapi');
+const Hapi   = require('@hapi/hapi');
 const secret = 'NeverShareYourSecret';
 
 // for debug options see: http://hapijs.com/tutorials/logging

--- a/test/dynamic_header_key.test.js
+++ b/test/dynamic_header_key.test.js
@@ -1,5 +1,5 @@
 const test   = require('tape');
-const Hapi   = require('hapi');
+const Hapi   = require('@hapi/hapi');
 const JWT    = require('jsonwebtoken');
 const secret = 'NeverShareYourSecret';
 

--- a/test/dynamic_key_server.js
+++ b/test/dynamic_key_server.js
@@ -1,5 +1,5 @@
-const Hapi = require('hapi');
-const Boom = require('boom');
+const Hapi = require('@hapi/hapi');
+const Boom = require('@hapi/boom');
 
 // for debug options see: http://hapijs.com/tutorials/logging
 const server = new Hapi.Server({ debug: false });

--- a/test/error_func_server.js
+++ b/test/error_func_server.js
@@ -1,4 +1,4 @@
-const Hapi   = require('hapi');
+const Hapi   = require('@hapi/hapi');
 const secret = 'NeverShareYourSecret';
 
 // for debug options see: http://hapijs.com/tutorials/logging

--- a/test/multiple_key_server.js
+++ b/test/multiple_key_server.js
@@ -1,5 +1,5 @@
-const Hapi = require('hapi');
-const Boom = require('boom');
+const Hapi = require('@hapi/hapi');
+const Boom = require('@hapi/boom');
 
 // for debug options see: http://hapijs.com/tutorials/logging
 const server = new Hapi.Server({ debug: false });

--- a/test/options_payload_validation.js
+++ b/test/options_payload_validation.js
@@ -1,6 +1,6 @@
 var test = require('tape');
-var Hapi = require('hapi');
-var Boom = require('boom');
+var Hapi = require('@hapi/hapi');
+var Boom = require('@hapi/boom');
 var JWT = require('jsonwebtoken');
 
 var secret = 'NeverShareYourSecret';

--- a/test/scheme-payload-server.js
+++ b/test/scheme-payload-server.js
@@ -1,6 +1,6 @@
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const secret = 'NeverShareYourSecret';
-const Boom = require('boom');
+const Boom = require('@hapi/boom');
 
 // for debug options see: http://hapijs.com/tutorials/logging
 const server = new Hapi.Server({ debug: false });

--- a/test/scheme-payload.test.js
+++ b/test/scheme-payload.test.js
@@ -1,7 +1,7 @@
 const test = require('tape');
 const JWT = require('jsonwebtoken');
 const secret = 'NeverShareYourSecret';
-const Boom = require('boom');
+const Boom = require('@hapi/boom');
 
 const server = require('./scheme-payload-server');
 

--- a/test/scheme-response-server.js
+++ b/test/scheme-response-server.js
@@ -1,4 +1,4 @@
-const Hapi   = require('hapi');
+const Hapi   = require('@hapi/hapi');
 const secret = 'NeverShareYourSecret';
 
 // for debug options see: http://hapijs.com/tutorials/logging

--- a/test/scopes_server.js
+++ b/test/scopes_server.js
@@ -1,4 +1,4 @@
-const Hapi   = require('hapi');
+const Hapi   = require('@hapi/hapi');
 const secret = 'NeverShareYourSecret';
 
 // for debug options see: http://hapijs.com/tutorials/logging

--- a/test/try_and_optional_auth_mode.test.js
+++ b/test/try_and_optional_auth_mode.test.js
@@ -1,5 +1,5 @@
 const test   = require('tape');
-const Hapi   = require('hapi');
+const Hapi   = require('@hapi/hapi');
 const JWT    = require('jsonwebtoken');
 const secret = 'NeverShareYourSecret';
 

--- a/test/validate_func.test.js
+++ b/test/validate_func.test.js
@@ -1,5 +1,5 @@
 const test   = require('tape');
-const Hapi   = require('hapi');
+const Hapi   = require('@hapi/hapi');
 const JWT    = require('jsonwebtoken');
 const secret = 'NeverShareYourSecret';
 

--- a/test/verify_func_server.js
+++ b/test/verify_func_server.js
@@ -1,4 +1,4 @@
-const Hapi   = require('hapi');
+const Hapi   = require('@hapi/hapi');
 const secret = 'NeverShareYourSecret';
 
 // for debug options see: http://hapijs.com/tutorials/logging


### PR DESCRIPTION
`hapi` and `boom` are deprecated and are called `@hapi/hapi` and `@hapi/boom` instead now. This PR will introduce the new dependencies.