### PR TITLE
chore: update @hapi/boom dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/dwyl/hapi-auth-jwt2",
   "dependencies": {
-    "@hapi/boom": "^7.4.2",
+    "@hapi/boom": "^7.4.3",
     "cookie": "^0.3.1",
     "jsonwebtoken": "^8.1.0"
   },


### PR DESCRIPTION
Otherwise the following warning will appear because the version specified in the current `package.json` depends on `@hapi/hoek@^6`:
```
warning hapi-auth-jwt2 > @hapi/boom > @hapi/hoek@6.2.4: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
```