### PR TITLE
Add support for tokens in POST bodies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ node_modules
 # Vagrant VM (temporary files)
 .vagrant
 package-lock.json
+
+/.idea/

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Cookie = require('cookie'); // highly popular decoupled cookie parser
+const internals = {}; // see: http://hapijs.com/styleguide#module-globals
 
 /**
  * customOrDefaultKey is a re-useable method to determing if the developer
@@ -29,6 +30,7 @@ module.exports = function extract(request, options) {
   const cookieKey = customOrDefaultKey(options, 'cookieKey', 'token');
   const headerKey = customOrDefaultKey(options, 'headerKey', 'authorization');
   const urlKey = customOrDefaultKey(options, 'urlKey', 'token');
+  const payloadKey = customOrDefaultKey(options, 'payloadKey', 'token');
   const pattern = new RegExp(options.tokenType + '\\s+([^$]+)', 'i');
 
   if (urlKey && request.query[urlKey]) {
@@ -44,9 +46,26 @@ module.exports = function extract(request, options) {
   } else if (cookieKey && request.headers.cookie) {
     auth = Cookie.parse(request.headers.cookie)[cookieKey];
   }
+  if (payloadKey && request.payload && request.payload[payloadKey]) {
+    auth = request.payload[payloadKey];
+  }
+  if (!auth && options.customExtractionFunc) {
+    auth = options.customExtractionFunc(request);
+  }
 
   // strip pointless "Bearer " label & any whitespace > http://git.io/xP4F
-  return auth ? auth.replace(/Bearer/gi, '').replace(/ /g, '') : null;
+  auth = auth ? auth.replace(/Bearer/gi, '').replace(/ /g, '') : null;
+  // If we are receiving a headerless JWT token let reconstruct it using the custom function
+  if (
+    options.headless &&
+    typeof options.headless === 'object' &&
+    internals.isHeadless(auth)
+  ) {
+    auth = `${Buffer.from(JSON.stringify(options.headless)).toString(
+      'base64'
+    )}.${auth}`;
+  }
+  return auth;
 };
 
 /**
@@ -68,6 +87,6 @@ module.exports.isValid = function isValid(token) {
  * // returns true if the token consist of 3 parts
  * const isheadless = isHeadless(token);
  */
-module.exports.isHeadless = function isHeadless(token) {
-  return token.split('.').length === 2;
+internals.isHeadless = function isHeadless(token) {
+  return token && token.split('.').length === 2;
 };

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -102,6 +102,14 @@ declare namespace hapiAuthJwt2 {
         headerKey?: string | boolean;
 
         /**
+         * If you want to set a custom key for your payload token use the
+         * `payloadKey` option. To disable payload token set payloadKey to `false` or
+         * ''.
+         * @default 'token'
+         */
+        payloadKey?: string | boolean;
+
+        /**
          * Allow custom token type, e.g. `Authorization: <tokenType> 12345678`
          */
         tokenType?: string;
@@ -113,6 +121,20 @@ declare namespace hapiAuthJwt2 {
          * @default false
          */
         complete?: boolean;
+
+        /**
+         * Set to `true` to allow the `payloadFunc` to attempt to extract the token from
+         * POST bodies
+         * @default false
+         */
+        attemptToExtractTokenInPayload?: boolean;
+
+        /**
+         * Custom token extraction function used to allow consumers to pull tokens from
+         * sources not foreseen by the module, for example... YAR
+         * @default false
+         */
+        customExtractionFunc?(request: Request): string;
     }
 
     interface RegisterOptions {

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 const Boom = require('@hapi/boom'); // error handling https://github.com/hapijs/boom
 const assert = require('assert'); // use assert to check if options are set
 const JWT = require('jsonwebtoken'); // https://github.com/docdis/learn-json-web-tokens
-const extract = require('./extract'); // extract token from Auth Header, URL or Coookie
+const extract = require('./extract'); // extract token from Auth Header, URL or Cookie
 const pkg = require('../package.json'); // use package name and version rom package.json
 const internals = {}; // see: http://hapijs.com/styleguide#module-globals
 
@@ -35,6 +35,8 @@ exports.plugin.pkg = pkg; // hapi requires attributes for a plugin.
 exports.plugin.requirements = {
   hapi: '>=17',
 };
+
+internals.FIRST_PASS_AUTHENTICATION_FAILED = 'firstPassAuthenticationFailed';
 
 /**
  * checkObjectType returns the class of the object's prototype
@@ -80,6 +82,195 @@ internals.verifyJwt = function(token, keys, options) {
   throw error;
 };
 
+internals.authenticate = async function(token, options, request, h) {
+  let tokenType = options.tokenType || 'Token'; // see: https://git.io/vXje9
+  let decoded;
+
+  if (!token && request.auth.mode === 'optional') {
+    return {
+      error: internals.raiseError(options, 'unauthorized', null, tokenType),
+      payload: {
+        credentials: tokenType,
+      },
+    };
+  }
+
+  if (!token) {
+    return {
+      error: internals.raiseError(
+        options,
+        'unauthorized',
+        'token is null',
+        tokenType
+      ),
+      payload: {
+        credentials: tokenType,
+      },
+    };
+  }
+
+  // quick check for validity of token format
+  if (!extract.isValid(token)) {
+    return {
+      error: internals.raiseError(
+        options,
+        'unauthorized',
+        'Invalid token format',
+        tokenType
+      ),
+      payload: {
+        credentials: token,
+      },
+    };
+  }
+  // verification is done later, but we want to avoid decoding if malformed
+  request.auth.token = token; // keep encoded JWT available in the request
+  // otherwise use the same key (String) to validate all JWTs
+  try {
+    decoded = JWT.decode(token, { complete: options.complete || false });
+  } catch (e) {
+    return {
+      error: internals.raiseError(
+        options,
+        'unauthorized',
+        'Invalid token format',
+        tokenType
+      ),
+      payload: {
+        credentials: token,
+      },
+    };
+  }
+
+  if (typeof options.validate === 'function') {
+    const { keys, extraInfo } = await internals.getKeys(decoded, options);
+
+    /* istanbul ignore else */
+    if (extraInfo) {
+      request.plugins[pkg.name] = { extraInfo };
+    }
+
+    let verify_decoded;
+    try {
+      verify_decoded = internals.verifyJwt(token, keys, options);
+    } catch (verify_err) {
+      let err_message =
+        verify_err.message === 'jwt expired'
+          ? 'Expired token'
+          : 'Invalid token';
+      return {
+        error: internals.raiseError(
+          options,
+          'unauthorized',
+          err_message,
+          tokenType
+        ),
+        payload: { credentials: token },
+      };
+    }
+
+    try {
+      let {
+        isValid,
+        credentials,
+        response,
+        errorMessage,
+      } = await options.validate(verify_decoded, request, h);
+      if (response !== undefined) {
+        return { response };
+      }
+      if (!isValid) {
+        // invalid credentials
+        return {
+          error: internals.raiseError(
+            options,
+            'unauthorized',
+            errorMessage || 'Invalid credentials',
+            tokenType
+          ),
+          payload: { credentials: decoded },
+        };
+      }
+      // valid key and credentials
+      return {
+        payload: {
+          credentials:
+            credentials && typeof credentials === 'object'
+              ? credentials
+              : decoded,
+          artifacts: token,
+        },
+      };
+    } catch (validate_err) {
+      return {
+        error: internals.raiseError(options, 'boomify', validate_err),
+        payload: {
+          credentials: decoded,
+        },
+      };
+    }
+  }
+  // see: https://github.com/dwyl/hapi-auth-jwt2/issues/130
+  try {
+    let { isValid, credentials } = await options.verify(decoded, request);
+    if (!isValid) {
+      return {
+        error: internals.raiseError(
+          options,
+          'unauthorized',
+          'Invalid credentials',
+          tokenType
+        ),
+        payload: { credentials: decoded },
+      };
+    }
+
+    return {
+      payload: {
+        credentials: credentials,
+        artifacts: token,
+      },
+    };
+  } catch (verify_error) {
+    return {
+      error: internals.raiseError(options, 'boomify', verify_error),
+      payload: {
+        credentials: decoded,
+      },
+    };
+  }
+};
+
+// allow custom error raising or default to Boom if no errorFunc is defined
+internals.raiseError = function raiseError(
+  options,
+  errorType,
+  message,
+  scheme,
+  attributes
+) {
+  let errorContext = {
+    errorType: errorType,
+    message: message,
+    scheme: scheme,
+    attributes: attributes,
+  };
+
+  if (internals.isFunction(options.errorFunc)) {
+    errorContext = options.errorFunc(errorContext);
+  }
+  // Since it is clearly specified in the docs that
+  // the errorFunc must return an object with keys:
+  // errorType and message, we need not worry about
+  // errorContext being undefined
+
+  return Boom[errorContext.errorType](
+    errorContext.message,
+    errorContext.scheme,
+    errorContext.attributes
+  );
+};
+
 /**
  * implementation is the "main" interface to the plugin and contains all the
  * "implementation details" (methods) such as authenicate, response & raiseError
@@ -96,30 +287,6 @@ internals.implementation = function(server, options) {
     'validate OR verify function is required!'
   );
 
-  // allow custom error raising or default to Boom if no errorFunc is defined
-  function raiseError(errorType, message, scheme, attributes) {
-    let errorContext = {
-      errorType: errorType,
-      message: message,
-      scheme: scheme,
-      attributes: attributes,
-    };
-
-    if (internals.isFunction(options.errorFunc)) {
-      errorContext = options.errorFunc(errorContext);
-    }
-    // Since it is clearly speacified in the docs that
-    // the errorFunc must return an object with keys:
-    // errorType and message, we need not worry about
-    // errorContext being undefined
-
-    return Boom[errorContext.errorType](
-      errorContext.message,
-      errorContext.scheme,
-      errorContext.attributes
-    );
-  }
-
   return {
     /**
      * authenticate is the "work horse" of the plugin. it's the method that gets
@@ -131,120 +298,24 @@ internals.implementation = function(server, options) {
      */
     authenticate: async function(request, h) {
       let token = extract(request, options); // extract token Header/Cookie/Query
-      let tokenType = options.tokenType || 'Token'; // see: https://git.io/vXje9
-      let decoded;
-
-      if (!token) {
-        return h.unauthenticated(raiseError('unauthorized', null, tokenType), {
-          credentials: tokenType,
-        });
-      }
-
-      // If we are receiving a headerless JWT token let reconstruct it using the custom function
       if (
-        options.headless &&
-        typeof options.headless === 'object' &&
-        extract.isHeadless(token)
+        token == null &&
+        options.attemptToExtractTokenInPayload &&
+        request.method.toLowerCase() === 'post'
       ) {
-        token = `${Buffer.from(JSON.stringify(options.headless)).toString(
-          'base64'
-        )}.${token}`;
-      }
-
-      // quick check for validity of token format
-      if (!extract.isValid(token)) {
-        return h.unauthenticated(
-          raiseError('unauthorized', 'Invalid token format', tokenType),
-          { credentials: token }
-        );
-      }
-      // verification is done later, but we want to avoid decoding if malformed
-      request.auth.token = token; // keep encoded JWT available in the request
-      // otherwise use the same key (String) to validate all JWTs
-      try {
-        decoded = JWT.decode(token, { complete: options.complete || false });
-      } catch (e) {
-        return h.unauthenticated(
-          raiseError('unauthorized', 'Invalid token format', tokenType),
-          { credentials: token }
-        );
-      }
-
-      if (typeof options.validate === 'function') {
-        const { keys, extraInfo } = await internals.getKeys(decoded, options);
-
-        /* istanbul ignore else */
-        if (extraInfo) {
-          request.plugins[pkg.name] = { extraInfo };
-        }
-
-        let verify_decoded;
-        try {
-          verify_decoded = internals.verifyJwt(token, keys, options);
-        } catch (verify_err) {
-          let err_message =
-            verify_err.message === 'jwt expired'
-              ? 'Expired token'
-              : 'Invalid token';
-          return h.unauthenticated(
-            raiseError('unauthorized', err_message, tokenType),
-            { credentials: token }
-          );
-        }
-
-        try {
-          let {
-            isValid,
-            credentials,
-            response,
-            errorMessage,
-          } = await options.validate(verify_decoded, request, h);
-          if (response !== undefined) {
-            return h.response(response).takeover();
-          }
-          if (!isValid) {
-            // invalid credentials
-            return h.unauthenticated(
-              raiseError(
-                'unauthorized',
-                errorMessage || 'Invalid credentials',
-                tokenType
-              ),
-              { credentials: decoded }
-            );
-          }
-          // valid key and credentials
-          return h.authenticated({
-            credentials:
-              credentials && typeof credentials === 'object'
-                ? credentials
-                : decoded,
-            artifacts: token,
-          });
-        } catch (validate_err) {
-          return h.unauthenticated(raiseError('boomify', validate_err), {
-            credentials: decoded,
-          });
-        }
-      }
-      // see: https://github.com/dwyl/hapi-auth-jwt2/issues/130
-      try {
-        let { isValid, credentials } = await options.verify(decoded, request);
-        if (!isValid) {
-          return h.unauthenticated(
-            raiseError('unauthorized', 'Invalid credentials', tokenType),
-            { credentials: decoded }
-          );
-        }
-
         return h.authenticated({
-          credentials: credentials,
-          artifacts: token,
+          credentials: {
+            error: internals.FIRST_PASS_AUTHENTICATION_FAILED,
+          },
         });
-      } catch (verify_error) {
-        return h.unauthenticated(raiseError('boomify', verify_error), {
-          credentials: decoded,
-        });
+      }
+      const result = await internals.authenticate(token, options, request, h);
+      if (result.error) {
+        return h.unauthenticated(result.error, result.payload);
+      } else if (result.response) {
+        return h.response(result.response).takeover();
+      } else {
+        return h.authenticated(result.payload);
       }
     },
     /**
@@ -256,7 +327,21 @@ internals.implementation = function(server, options) {
      * the next plugin in the list.
      * @returns {Boolean} true. always return true (unless there's an error...)
      */
-    payload: function(request, h) {
+    payload: async function(request, h) {
+      if (
+        options.attemptToExtractTokenInPayload &&
+        request.auth.credentials.error ===
+          internals.FIRST_PASS_AUTHENTICATION_FAILED
+      ) {
+        const token = extract(request, options);
+        const result = await internals.authenticate(token, options, request, h);
+        if (result && !result.error && result.payload) {
+          request.auth.credentials = result.payload.credentials;
+          request.auth.token = result.payload.token;
+        } else {
+          return result.error;
+        }
+      }
       const payloadFunc = options.payloadFunc;
       if (payloadFunc && typeof payloadFunc === 'function') {
         return payloadFunc(request, h);
@@ -280,13 +365,13 @@ internals.implementation = function(server, options) {
         ) {
           return responseFunc(request, h)
             .then(() => h.continue)
-            .catch(err => raiseError('boomify', err));
+            .catch(err => internals.raiseError(options, 'boomify', err));
         }
         try {
           // allow responseFunc to decorate or throw
           responseFunc(request, h);
         } catch (err) {
-          throw raiseError('boomify', err);
+          throw internals.raiseError(options, 'boomify', err);
         }
       }
       return h.continue;

--- a/package.json
+++ b/package.json
@@ -40,6 +40,10 @@
     {
       "name": "Samy Al Zahrani",
       "user": "@salzhrani"
+    },
+    {
+      "name": "Steven Leadbeater",
+      "user": "@LedSysUK <stevenleadbeater@live.co.uk>"
     }
   ],
   "license": "ISC",
@@ -58,7 +62,7 @@
     "aguid": "^2.0.0",
     "eslint": "^5.9.0",
     "eslint-plugin-prettier": "^3.0.0",
-    "nyc": "^13.1.0",
+    "nyc": "^14.1.1",
     "pre-commit": "^1.2.2",
     "prettier": "^1.15.2",
     "tap-nyc": "^1.0.3",

--- a/test/custom_extraction.test.js
+++ b/test/custom_extraction.test.js
@@ -1,0 +1,65 @@
+const test   = require('tape');
+const JWT    = require('jsonwebtoken');
+const secret = 'NeverShareYourSecret';
+const server = require('./custom_extraction_auth_server.js');
+
+test("Attempt to access restricted content using inVALID Payload Token", async function(t) {
+  const token = JWT.sign({ id: 123, "name": "Charlie" }, 'badsecret');
+  const options = {
+    method: "POST",
+    url: "/privado",
+    headers: { "custom-property": token },
+  };
+  // console.log(options);
+  const response = await server.inject(options);
+  t.equal(response.statusCode, 401, "Invalid token should error!");
+  t.end();
+});
+
+test("Attempt to access restricted content with VALID Token but malformed Payload", async function(t) {
+  const token = JWT.sign({ id: 123, "name": "Charlie" }, secret);
+  const options = {
+    method: "POST",
+    url: "/privado",
+    headers: { "not-the-right-token-key": token },
+  };
+  // server.inject lets us simulate an http request
+  const response = await server.inject(options);
+    t.equal(response.statusCode, 401, "Valid Token but inVALID PAYLOAD should fail!");
+    t.end();
+});
+
+test("Access restricted content with VALID Token Payload", async function(t) {
+  const token = JWT.sign({ id: 123, "name": "Charlie" }, secret);
+  const options = {
+    method: "POST",
+    url: "/privado",
+    headers: { "custom-property": token },
+  };
+  // server.inject lets us simulate an http request
+  const response = await server.inject(options);
+    t.equal(response.statusCode, 200, "VALID PAYLOAD Token should succeed!");
+    t.end();
+});
+
+/** Regressions Tests for https://github.com/dwyl/hapi-auth-jwt2/issues/65 **/
+
+// supply valid Token Auth Header but invalid Payload
+// should succeed because Auth Header is first
+test("Authorization Header should take precedence over any payload", async function(t) {
+  const token = JWT.sign({ id: 123, "name": "Charlie" }, secret);
+  const options = {
+    method: "POST",
+    url: "/privado",
+    headers: {
+      authorization: "Bearer " + token,
+      "custom-property": "malformed.token",
+    },
+  };
+  const response = await server.inject(options);
+  // console.log(' - - - - - - - - - - - - - - - response:')
+  // console.log(response);
+  t.equal(response.statusCode, 200, 'Ignores payload when Auth Header is set');
+  t.end();
+});
+

--- a/test/custom_extraction_auth_server.js
+++ b/test/custom_extraction_auth_server.js
@@ -1,0 +1,53 @@
+const Hapi   = require('@hapi/hapi');
+const secret = 'NeverShareYourSecret';
+
+// for debug options see: http://hapijs.com/tutorials/logging
+const server = new Hapi.Server({ debug: false });
+
+const db = {
+  "123": { allowed: true,  "name": "Charlie"  },
+  "321": { allowed: false, "name": "Old Gregg"}
+};
+
+// defining our own validate function lets us do something
+// useful/custom with the decodedToken before reply(ing)
+const validate = async function (decoded, request) {
+  if (db[decoded.id].allowed) {
+    return {isValid: true};
+  }
+  else {
+    return {isValid: false};
+  }
+};
+
+const privado = function(req, h) {
+  return 'worked';
+};
+
+const init = async () =>{
+  try {
+    await server.register(require('../'));
+    server.auth.strategy('jwt', 'jwt', {
+      key: secret,
+      validate,
+      verifyOptions: { algorithms: [ 'HS256' ] }, // only allow HS256 algorithm
+      customExtractionFunc: request => {
+        return request.headers["custom-property"];
+      },
+    });
+
+    server.route([
+      { method: 'POST', path: '/privado', handler: privado, config: { auth: 'jwt' } },
+    ]);
+  } catch(e) {
+    throw e;
+  }
+}
+init();
+
+process.on('unhandledRejection', function(reason, p){
+  console.error("Possibly Unhandled Rejection at: Promise ", p, " reason: ", reason);
+  // application specific logging here
+});
+
+module.exports = server;

--- a/test/payload.test.js
+++ b/test/payload.test.js
@@ -1,0 +1,91 @@
+const test   = require('tape');
+const JWT    = require('jsonwebtoken');
+const secret = 'NeverShareYourSecret';
+const server = require('./payload_auth_server.js');
+
+test("Attempt to access restricted content using inVALID Payload Token", async function(t) {
+  const token = JWT.sign({ id: 123, "name": "Charlie" }, 'badsecret');
+  const options = {
+    method: "POST",
+    url: "/privado",
+    payload: { token: token },
+  };
+  // console.log(options);
+  const response = await server.inject(options);
+  t.equal(response.statusCode, 401, "Invalid token should error!");
+  t.end();
+});
+
+test("Attempt to access restricted content with VALID Token but malformed Payload", async function(t) {
+  const token = JWT.sign({ id: 123, "name": "Charlie" }, secret);
+  const options = {
+    method: "POST",
+    url: "/privado",
+    payload: { notTheRightTokenKey: token },
+  };
+  // server.inject lets us simulate an http request
+  const response = await server.inject(options);
+    t.equal(response.statusCode, 401, "Valid Token but inVALID PAYLOAD should fail!");
+    t.end();
+});
+
+test("Access restricted content with VALID Token Payload", async function(t) {
+  const token = JWT.sign({ id: 123, "name": "Charlie" }, secret);
+  const options = {
+    method: "POST",
+    url: "/privado",
+    payload: { token: token },
+  };
+  // server.inject lets us simulate an http request
+  const response = await server.inject(options);
+    t.equal(response.statusCode, 200, "VALID PAYLOAD Token should succeed!");
+    t.end();
+});
+
+/** Regressions Tests for https://github.com/dwyl/hapi-auth-jwt2/issues/65 **/
+
+// supply valid Token Auth Header but invalid Payload
+// should succeed because Auth Header is first
+test("Authorization Header should take precedence over any payload", async function(t) {
+  const token = JWT.sign({ id: 123, "name": "Charlie" }, secret);
+  const options = {
+    method: "POST",
+    url: "/privado",
+    headers: {
+      authorization: "Bearer " + token
+    },
+    payload: { token: "malformed.token" },
+  };
+  const response = await server.inject(options);
+    // console.log(' - - - - - - - - - - - - - - - response:')
+    // console.log(response);
+    t.equal(response.statusCode, 200, "Ignores payload when Auth Header is set");
+    t.end();
+});
+
+test("Attempt to access restricted content with payloadKey=false", async function(t) {
+  const token = JWT.sign({ id: 123, "name": "Charlie" }, secret);
+  const options = {
+    method: "POST",
+    url: "/privadonopayload",
+    payload: { token: token },
+  };
+  // server.inject lets us simulate an http request
+  const response = await server.inject(options);
+    t.equal(response.statusCode, 401, "Disabled payload auth shouldn't accept valid token!");
+    t.end();
+});
+
+test("Attempt to access restricted content with payloadKey=''", async function(t) {
+  const token = JWT.sign({ id: 123, "name": "Charlie" }, secret);
+  const options = {
+    method: "POST",
+    url: "/privadonopayload2",
+    payload: { token: token },
+  };
+  // server.inject lets us simulate an http request
+  const response = await server.inject(options);
+    t.equal(response.statusCode, 401, "Disabled payload auth shouldn't accept valid token!");
+    t.end();
+});
+

--- a/test/payload_auth_server.js
+++ b/test/payload_auth_server.js
@@ -1,0 +1,69 @@
+const Hapi   = require('@hapi/hapi');
+const secret = 'NeverShareYourSecret';
+
+// for debug options see: http://hapijs.com/tutorials/logging
+const server = new Hapi.Server({ debug: false });
+
+const db = {
+  "123": { allowed: true,  "name": "Charlie"  },
+  "321": { allowed: false, "name": "Old Gregg"}
+};
+
+// defining our own validate function lets us do something
+// useful/custom with the decodedToken before reply(ing)
+const validate = async function (decoded, request) {
+  if (db[decoded.id].allowed) {
+    return {isValid: true};
+  }
+  else {
+    return {isValid: false};
+  }
+};
+
+const privado = function(req, h) {
+  return 'worked';
+};
+
+const init = async () =>{
+  try {
+    await server.register(require('../'));
+    server.auth.strategy('jwt', 'jwt', {
+      key: secret,
+      validate,
+      verifyOptions: { algorithms: [ 'HS256' ] }, // only allow HS256 algorithm
+      attemptToExtractTokenInPayload: true,
+    });
+
+    server.auth.strategy('jwt-nopayload', 'jwt', {
+      key: secret,
+      validate,
+      verifyOptions: { algorithms: [ 'HS256' ] }, // only allow HS256 algorithm
+      payloadKey: false,
+      attemptToExtractTokenInPayload: true,
+    });
+
+    server.auth.strategy('jwt-nopayload2', 'jwt', {
+      key: secret,
+      validate,
+      verifyOptions: { algorithms: [ 'HS256' ] }, // only allow HS256 algorithm
+      payloadKey: '',
+      attemptToExtractTokenInPayload: true,
+    });
+
+    server.route([
+      { method: 'POST', path: '/privado', handler: privado, config: { auth: { strategies: ['jwt'], payload: 'optional' } } },
+      { method: 'POST', path: '/privadonopayload', handler: privado, config: { auth: { strategies: ['jwt-nopayload'], payload: 'optional' } } },
+      { method: 'POST', path: '/privadonopayload2', handler: privado, config: { auth: { strategies: ['jwt-nopayload2'], payload: 'optional' } } },
+    ]);
+  } catch(e) {
+    throw e;
+  }
+}
+init();
+
+process.on('unhandledRejection', function(reason, p){
+  console.error("Possibly Unhandled Rejection at: Promise ", p, " reason: ", reason);
+  // application specific logging here
+});
+
+module.exports = server;

--- a/test/validate_func.test.js
+++ b/test/validate_func.test.js
@@ -8,55 +8,54 @@ test('Should respond with 500 series error when validate errs', async function (
   const server = new Hapi.Server({ debug: false });
   try {
     await server.register(require('../'));
-  } catch(err) {
+  } catch (err) {
     t.ifError(err, 'No error registering hapi-auth-jwt2 plugin');
   }
-    server.auth.strategy('jwt', 'jwt', {
-      key: secret,
-      validate: function (decoded, request, h) {
-        if (decoded.id === 138) {
-          throw new Error('ASPLODE');
-        }
-        if (decoded.id === 139) {
-          return { isValid: false }
-        }
-        if (decoded.id === 140) {
-          return { isValid: false, errorMessage: 'Bad ID' }
-        }
-        return { response:  h.redirect('https://dwyl.com') }
-      },
-      verifyOptions: {algorithms: ['HS256']}
-    });
+  server.auth.strategy('jwt', 'jwt', {
+    key: secret,
+    validate: function (decoded, request, h) {
+      if (decoded.id === 138) {
+        throw new Error('ASPLODE');
+      }
+      if (decoded.id === 139) {
+        return { isValid: false }
+      }
+      if (decoded.id === 140) {
+        return { isValid: false, errorMessage: 'Bad ID' }
+      }
+      return { response:  h.redirect('https://dwyl.com') }
+    },
+    verifyOptions: {algorithms: ['HS256']}
+  });
 
-    server.route({
-      method: 'POST',
-      path: '/privado',
-      handler: function (req, h) { return 'PRIVADO'; },
-      config: { auth: 'jwt' }
-    });
+  server.route({
+    method: 'POST',
+    path: '/privado',
+    handler: function (req, h) { return 'PRIVADO'; },
+    config: { auth: 'jwt' }
+  });
 
-    let options = {
-      method: 'POST',
-      url: '/privado',
-      headers: {Authorization: JWT.sign({id: 138, name: 'Test'}, secret)}
-    };
+  let options = {
+    method: 'POST',
+    url: '/privado',
+    headers: {Authorization: JWT.sign({id: 138, name: 'Test'}, secret)}
+  };
 
-    let response = await server.inject(options);
-      t.equal(response.statusCode, 500, 'Server returned 500 for validate error');
-    
-    options.headers.Authorization = JWT.sign({id: 200, name: 'Test'}, secret);
-    response = await server.inject(options);
-      t.equal(response.statusCode, 302, 'Server redirect status code');
-      t.equal(response.headers.location, 'https://dwyl.com', 'Server redirect header');
-      
-    options.headers.Authorization = JWT.sign({id: 139, name: 'Test'}, secret);
-    response = await server.inject(options);
-      t.equal(response.statusCode, 401, 'Server errors when isValid false');
-      t.equal(response.result.message, 'Invalid credentials', 'Default error message when custom not provided');
+  let response = await server.inject(options);
+  t.equal(response.statusCode, 500, 'Server returned 500 for validate error');
 
-    options.headers.Authorization = JWT.sign({id: 140, name: 'Test'}, secret);
-    response = await server.inject(options);
-      t.equal(response.result.message, 'Bad ID', 'Custom error message when provided');
-      t.end();
+  options.headers.Authorization = JWT.sign({ id: 200, name: 'Test' }, secret);
+  response = await server.inject(options);
+  t.equal(response.statusCode, 302, 'Server redirect status code');
+  t.equal(response.headers.location, 'https://dwyl.com', 'Server redirect header');
 
+  options.headers.Authorization = JWT.sign({id: 139, name: 'Test'}, secret);
+  response = await server.inject(options);
+  t.equal(response.statusCode, 401, 'Server errors when isValid false');
+  t.equal(response.result.message, 'Invalid credentials', 'Default error message when custom not provided');
+
+  options.headers.Authorization = JWT.sign({id: 140, name: 'Test'}, secret);
+  response = await server.inject(options);
+  t.equal(response.result.message, 'Bad ID', 'Custom error message when provided');
+  t.end();
 });


### PR DESCRIPTION
As our project requires absolute support for screen readers, we cannot use JS in the front end. This MR allows the parsing of JWTs from post bodies for the initial hand off from an OAuth server posting the token to the node.js server which can subsequently store the token in YAR

fixes #319