### PR TITLE
Update versions of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
   },
   "homepage": "https://github.com/dwyl/hapi-auth-jwt2",
   "dependencies": {
-    "@hapi/boom": "^7.4.3",
-    "cookie": "^0.3.1",
-    "jsonwebtoken": "^8.1.0"
+    "@hapi/boom": "^8.0.1",
+    "cookie": "^0.4.0",
+    "jsonwebtoken": "^8.5.1"
   },
   "devDependencies": {
     "@hapi/hapi": "^18.0.0",


### PR DESCRIPTION
 This PR updates the dependencies (@hapi/boom, cookie & jsonwebtoken) to latest versions fixes #321