### PR TITLE
fixes #325 - multi auth support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -86,22 +86,15 @@ internals.authenticate = async function(token, options, request, h) {
   let tokenType = options.tokenType || 'Token'; // see: https://git.io/vXje9
   let decoded;
 
-  if (!token && request.auth.mode === 'optional') {
-    return {
-      error: internals.raiseError(options, 'unauthorized', null, tokenType),
-      payload: {
-        credentials: tokenType,
-      },
-    };
-  }
-
   if (!token) {
     return {
       error: internals.raiseError(
         options,
         'unauthorized',
         'token is null',
-        tokenType
+        tokenType,
+        null,
+        true
       ),
       payload: {
         credentials: tokenType,
@@ -116,7 +109,9 @@ internals.authenticate = async function(token, options, request, h) {
         options,
         'unauthorized',
         'Invalid token format',
-        tokenType
+        tokenType,
+        null,
+        true
       ),
       payload: {
         credentials: token,
@@ -247,7 +242,8 @@ internals.raiseError = function raiseError(
   errorType,
   message,
   scheme,
-  attributes
+  attributes,
+  isMissingToken
 ) {
   let errorContext = {
     errorType: errorType,
@@ -264,11 +260,17 @@ internals.raiseError = function raiseError(
   // errorType and message, we need not worry about
   // errorContext being undefined
 
-  return Boom[errorContext.errorType](
+  const error = Boom[errorContext.errorType](
     errorContext.message,
     errorContext.scheme,
     errorContext.attributes
   );
+
+  return isMissingToken
+    ? Object.assign(error, {
+        isMissing: true,
+      })
+    : error;
 };
 
 /**
@@ -339,6 +341,7 @@ internals.implementation = function(server, options) {
           request.auth.credentials = result.payload.credentials;
           request.auth.token = result.payload.token;
         } else {
+          delete result.error.isMissing;
           return result.error;
         }
       }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@hapi/hapi": "^18.0.0",
+    "@hapi/basic": "^5.1.1",
     "@types/hapi__hapi": "^18.2.0",
     "aguid": "^2.0.0",
     "eslint": "^5.9.0",

--- a/test/multi_auth.test.js
+++ b/test/multi_auth.test.js
@@ -1,0 +1,36 @@
+const test   = require('tape');
+const JWT    = require('jsonwebtoken');
+const secret = 'NeverShareYourSecret';
+const server = require('./multi_auth_server.js');
+
+test("Access restricted content with VALID Token Payload", async function(t) {
+  const token = JWT.sign({ id: 123, "name": "Charlie" }, secret);
+  const options = {
+    method: "POST",
+    url: "/privado",
+    payload: { token: token },
+  };
+  // server.inject lets us simulate an http request
+  const response = await server.inject(options);
+    t.equal(response.statusCode, 200, "VALID PAYLOAD Token should succeed!");
+    t.end();
+});
+
+// supply valid Basic Auth Header but invalid Payload
+// should succeed because Auth Header is first
+test("Authorization Header should take precedence over any payload", async function(t) {
+  const token = JWT.sign({ id: 123, "name": "Charlie" }, secret);
+  const options = {
+    method: "POST",
+    url: "/privado",
+    headers: {
+      authorization: "Basic dGVzdDpwYXNzd29yZA=="
+    },
+    payload: { token: "malformed.token" },
+  };
+  const response = await server.inject(options);
+    // console.log(' - - - - - - - - - - - - - - - response:')
+    // console.log(response);
+    t.equal(response.statusCode, 200, "Ignores payload when Auth Header is set");
+    t.end();
+});

--- a/test/multi_auth_server.js
+++ b/test/multi_auth_server.js
@@ -1,0 +1,74 @@
+const Hapi = require('@hapi/hapi');
+const secret = 'NeverShareYourSecret';
+
+// for debug options see: http://hapijs.com/tutorials/logging
+const server = new Hapi.Server({ debug: false });
+
+const db = {
+  '123': { allowed: true, name: 'Charlie' },
+  '321': { allowed: false, name: 'Old Gregg' },
+};
+
+// defining our own validate function lets us do something
+// useful/custom with the decodedToken before reply(ing)
+const validate = async function(decoded, request) {
+  if (db[decoded.id].allowed) {
+    return { isValid: true };
+  } else {
+    return { isValid: false };
+  }
+};
+
+const validateBasic = async (request, username, password, h) => {
+  if (password === 'password') {
+    return { isValid: true, credentials: { id: username, name: 'test' } };
+  } else {
+    return { isValid: false, credentials: null };
+  }
+};
+
+const privado = function(req, h) {
+  return 'worked';
+};
+
+const init = async () => {
+  try {
+    await server.register(require('../'));
+    await server.register(require('@hapi/basic'));
+
+    server.auth.strategy('jwt', 'jwt', {
+      key: secret,
+      validate,
+      verifyOptions: { algorithms: ['HS256'] }, // only allow HS256 algorithm
+      attemptToExtractTokenInPayload: true,
+    });
+
+    server.auth.strategy('simple', 'basic', { validate: validateBasic });
+
+    server.route([
+      {
+        method: 'POST',
+        path: '/privado',
+        handler: privado,
+        config: {
+          auth: { strategies: ['jwt', 'simple'], payload: 'optional' },
+        },
+      },
+    ]);
+  } catch (e) {
+    throw e;
+  }
+};
+init();
+
+process.on('unhandledRejection', function(reason, p) {
+  console.error(
+    'Possibly Unhandled Rejection at: Promise ',
+    p,
+    ' reason: ',
+    reason
+  );
+  // application specific logging here
+});
+
+module.exports = server;


### PR DESCRIPTION
hapi auth isMissing is controlled by whether or not a message is set on errors, only returning boom.unauthorised without a message was setting isMissing to true, allowing subsequent auth schemes to execute. Rather than rely on this obscure semantic, set the isMissing property to true on errors we can categorise as missing tokens. fixes #325 