### PR TITLE
Fix typings to allow key function

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -45,7 +45,7 @@ declare namespace hapiAuthJwt2 {
         /**
          * The secret key used to check the signature of the token *or* a *key lookup function*
          */
-        key?: string | string[] | Promise<{ isValid: boolean; key: string; extraInfo?: ExtraInfo }>;
+        key?: string | string[] | ((decodedToken: any) => Promise<{ key: string | string[]; extraInfo?: ExtraInfo }>);
 
         /**
          * The function which is run once the Token has been decoded


### PR DESCRIPTION
Currently a promise is allowed instead which seems like a mistake since both docs and actual usage
use a function
https://github.com/dwyl/hapi-auth-jwt2/blob/fa051b3d0976397416aef4faef2c683060178437/lib/index.js#L66

isValid was removed from docs but not more typings in
https://github.com/dwyl/hapi-auth-jwt2/commit/2a2eb78f7d11ace278560b1e8e8c7daf14dd2e73