### PR TITLE
Update to Hapi v19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
-  - "8"
   - "10"
-  - "11"
   - "node"
 env:
   - JWT_SECRET="EverythingIsAwesome!"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "10"
+  - "12"
   - "node"
 env:
   - JWT_SECRET="EverythingIsAwesome!"

--- a/README.md
+++ b/README.md
@@ -622,7 +622,7 @@ we felt it was prudent to make it clear to people that Hapi.js
 (_the core framework_) has
 [dropped support for Node.js 10](https://github.com/dwyl/hapi-auth-jwt2/issues/338#issuecomment-583716612)
 and people should treat _this_ package
-as a no longer supporting the older versions of Node. <br />
+as no longer supporting the older versions of Node. <br />
 `hapi-auth-jwt2` version `8.x.x`
 is compatible with Hapi.js version `17.x.x` - `19.x.x`
 <br />`hapi-auth-jwt2` version `7.x.x` is compatible with `16.x.x`

--- a/README.md
+++ b/README.md
@@ -167,9 +167,9 @@ signature `async function(decoded)` where:
     - `decoded` - the ***decoded*** but ***unverified*** JWT received from client
     - Returns an object `{ key, extraInfo }` where:
         - `key` - the secret key (or array of keys to try)
-        - `extraInfo` - (***optional***) any additional information that you would like to use in `validate` which can be accessed 
+        - `extraInfo` - (***optional***) any additional information that you would like to use in `validate` which can be accessed
         via `request.plugins['hapi-auth-jwt2'].extraInfo`
-    - Throws a Boom error when key lookup fails.  Refer to [this example implementation](https://github.com/dwyl/hapi-auth-jwt2/blob/master/test/dynamic_key_server.js) 
+    - Throws a Boom error when key lookup fails.  Refer to [this example implementation](https://github.com/dwyl/hapi-auth-jwt2/blob/master/test/dynamic_key_server.js)
     and [its associated test](https://github.com/dwyl/hapi-auth-jwt2/blob/master/test/dynamic_key.test.js) for a working example.
 - `validate` - (***required***) the function which is run once the Token has been decoded with
  signature `async function(decoded, request, h)` where:
@@ -613,9 +613,22 @@ because with a `verify` you can incorporate your own custom-logic.
 
 ### Compatibility
 
-`hapi-auth-jwt2` version `8.x.x` is compatible with Hapi.js version `17.x.x`, while `7.x.x` is compatible with `16.x.x`
+**`hapi-auth-jwt2`** version **`9.x.x`** is compatible with **Hapi.js `19.x.x`**
+which only supports **Node.js 12+**.
+While **`hapi-auth-jwt2`** version `9.0.0`
+does not have _any_ code changes from `v8.8.1`
+(_so there should not be any need to update your code that uses this plugin_),
+we felt it was prudent to make it clear to people that Hapi.js
+(_the core framework_) has
+[dropped support for Node.js 10](https://github.com/dwyl/hapi-auth-jwt2/issues/338#issuecomment-583716612)
+and people should treat _this_ package
+as a no longer supporting the older versions of Node. <br />
+`hapi-auth-jwt2` version `8.x.x`
+is compatible with Hapi.js version `17.x.x` - `19.x.x`
+<br />`hapi-auth-jwt2` version `7.x.x` is compatible with `16.x.x`
 `15.x.x` `14.x.x` `13.x.x` `12.x.x` `11.x.x` `10.x.x` `9.x.x` and `8.x.x`
-hapi `17.x.x` is a major rewrite that's why it is version `8.x.x` of the plugin is not backward compatible!
+Hapi `17.x.x` is a _major_ rewrite that's why it is version `8.x.x`
+of the plugin is not backward compatible!
 
 However in the interest of
  security/performance we *recommend* using the [*latest version*](https://github.com/hapijs/hapi/) of Hapi.
@@ -675,10 +688,10 @@ https://github.com/dwyl/hapi-auth-jwt2/issues
 
 ## Contributing [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/dwyl/hapi-auth-jwt2/issues)
 
-If you spot an area for improvement, 
-please raise an issue: 
+If you spot an area for improvement,
+please raise an issue:
 https://github.com/dwyl/hapi-auth-jwt2/issues <br />
-*Someone* in the dwyl team is *always* online 
+*Someone* in the dwyl team is *always* online
 so we will usually answer within a few hours.
 
 

--- a/README.md
+++ b/README.md
@@ -627,7 +627,7 @@ as a no longer supporting the older versions of Node. <br />
 is compatible with Hapi.js version `17.x.x` - `19.x.x`
 <br />`hapi-auth-jwt2` version `7.x.x` is compatible with `16.x.x`
 `15.x.x` `14.x.x` `13.x.x` `12.x.x` `11.x.x` `10.x.x` `9.x.x` and `8.x.x`
-Hapi `17.x.x` is a _major_ rewrite that's why it is version `8.x.x`
+Hapi `17.x.x` is a _major_ rewrite that's why version `8.x.x`
 of the plugin is not backward compatible!
 
 However in the interest of

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "jsonwebtoken": "^8.5.1"
   },
   "devDependencies": {
-    "@hapi/hapi": "^18.4.0",
+    "@hapi/hapi": "^19.1.0",
     "@hapi/basic": "^5.1.1",
     "@types/hapi__hapi": "^18.2.5",
     "aguid": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "jsonwebtoken": "^8.5.1"
   },
   "devDependencies": {
+    "@hapi/basic": "^6.0.0",
     "@hapi/hapi": "^19.1.0",
-    "@hapi/basic": "^5.1.1",
     "@types/hapi__hapi": "^18.2.5",
     "aguid": "^2.0.0",
     "eslint": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "pre-commit": "^1.2.2",
     "prettier": "^1.19.1",
     "tap-nyc": "^1.0.3",
-    "tape": "^5.0.0-next.4"
+    "tape": "^4.13.0"
   },
   "engines": {
     "node": ">=8.10.0"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@hapi/basic": "^6.0.0",
     "@hapi/hapi": "^19.1.0",
-    "@types/hapi__hapi": "^18.2.5",
+    "@types/hapi__hapi": "^19.0.1	",
     "aguid": "^2.0.0",
     "eslint": "^6.6.0",
     "eslint-plugin-prettier": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "homepage": "https://github.com/dwyl/hapi-auth-jwt2",
   "dependencies": {
-    "@hapi/boom": "^8.0.1",
+    "@hapi/boom": "^9.0.0",
     "cookie": "^0.4.0",
     "jsonwebtoken": "^8.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@hapi/basic": "^6.0.0",
     "@hapi/hapi": "^19.1.0",
-    "@types/hapi__hapi": "^19.0.1	",
+    "@types/hapi__hapi": "^19.0.1",
     "aguid": "^2.0.0",
     "eslint": "^6.6.0",
     "eslint-plugin-prettier": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -61,13 +61,13 @@
     "@hapi/hapi": "^19.1.0",
     "@types/hapi__hapi": "^19.0.1",
     "aguid": "^2.0.0",
-    "eslint": "^6.6.0",
-    "eslint-plugin-prettier": "^3.1.1",
-    "nyc": "^15.0.0-beta.0",
+    "eslint": "^7.0.0-alpha.0",
+    "eslint-plugin-prettier": "^3.1.2",
+    "nyc": "^15.0.0",
     "pre-commit": "^1.2.2",
-    "prettier": "^1.18.2",
+    "prettier": "^1.19.1",
     "tap-nyc": "^1.0.3",
-    "tape": "^4.11.0"
+    "tape": "^5.0.0-next.4"
   },
   "engines": {
     "node": ">=8.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-auth-jwt2",
-  "version": "8.8.1",
+  "version": "9.0.0",
   "description": "Hapi.js Authentication Plugin/Scheme using JSON Web Tokens (JWT)",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/test/error_func.test.js
+++ b/test/error_func.test.js
@@ -11,7 +11,7 @@ test("Access a route that has no auth strategy", async function(t) {
   };
   // server.inject lets us simulate an http request
   const response = await server.inject(options);
-    t.equal(response.statusCode, 200, "GET / still works without token.");
+    t.equal(response.statusCode, 204, "GET / still works without token.");
     t.end();
 });
 
@@ -106,4 +106,3 @@ test("Custom Verification in 'required' mode ", async function(t) {
     t.equal(response.statusCode, 200, "GET /required bypasses verification");
     t.end();
 });
-

--- a/test/verify_func.test.js
+++ b/test/verify_func.test.js
@@ -11,7 +11,7 @@ test("Access a route that has no auth strategy", async function(t) {
   };
   // server.inject lets us simulate an http request
   const response = await server.inject(options);
-    t.equal(response.statusCode, 200, "GET / still works without token.");
+    t.equal(response.statusCode, 204, "GET / still works without token.");
     t.end();
 });
 


### PR DESCRIPTION
This pull request updates our `devDependency` on Hapi.js to v19 without changing any code! 🎉 
That means people _using_ this plugin should not need to make any changes to their apps.
The only reason we have chosen to release a new ***`major`*** version (`9.0.0`) is to indicate to people that the underlying framework (Hapi.js v19) has dropped support for Node.js v10. 

This PR contains:

+ [x] **Remove _Unsupported_ Versions** of **`Node.js`** from `.travis.yml` file #338
+ [x] Add note on compatibility of this package to Hapi v19 https://github.com/dwyl/hapi-auth-jwt2/issues/338#issuecomment-583761065
+ [x] Update version of **`dependency`** `@hapi/Boom` to 9.0.0 #336 
+ [x] Update **`devDependencies`**: #336 
  + [x] Update version of `@hapi/hapi` to 19.1.0 **`breaking change`** https://github.com/dwyl/hapi-auth-jwt2/issues/338#issuecomment-583716612
  + [x] Update version of `@hapi/basic` to 6.0.0 
  + [x] Update version of `@types/hapi__hapi` to 19.0.1
+ [x] Update two tests to assert `204` HTTP status code #339 
 