### PR TITLE
feat: store raw and decoded token under artifacts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -193,7 +193,10 @@ internals.authenticate = async function(token, options, request, h) {
             credentials && typeof credentials === 'object'
               ? credentials
               : decoded,
-          artifacts: token,
+          artifacts: {
+            token,
+            decoded,
+          },
         },
       };
     } catch (validate_err) {
@@ -223,7 +226,10 @@ internals.authenticate = async function(token, options, request, h) {
     return {
       payload: {
         credentials: credentials,
-        artifacts: token,
+        artifacts: {
+          token,
+          decoded,
+        },
       },
     };
   } catch (verify_error) {
@@ -381,7 +387,7 @@ internals.implementation = function(server, options) {
     },
 
     verify: async function(auth) {
-      const token = auth.artifacts;
+      const token = auth.artifacts.token;
       const decoded = JWT.decode(token, {
         complete: options.complete || false,
       });

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -343,6 +343,27 @@ test("Scheme should set token in request.auth.token", async function(t) {
   t.end();
 });
 
+test("Scheme should set artifacts in request.auth.artifacts", async function(t) {
+
+  const token = JWT.sign({ id: 123, "name": "Charlie" }, secret);
+  const options = {
+    method: "GET",
+    url: "/artifacts",
+    headers: { authorization: "Bearer " + token }
+  };
+
+  const response = await server.inject(options);
+
+  const decoded = JWT.decode(token);
+  const artifacts = {
+    token,
+    decoded,
+  }
+
+  t.same(response.result, artifacts, 'Artifacts are accesible from handler');
+  t.end();
+})
+
 test.onFinish(function () {
   server.stop(function(){});
 })

--- a/test/basic_server.js
+++ b/test/basic_server.js
@@ -36,6 +36,10 @@ const sendToken = function(req, h) {
   return req.auth.token;
 };
 
+const sendArtifacts = function(req, h) {
+  return req.auth.artifacts;
+};
+
 const longRunning = async function(req, h) {
   await wait(1100);
   try {
@@ -96,6 +100,7 @@ const init = async () =>{
     server.route([
       { method: 'GET', path: '/', handler: home, config: { auth: false } },
       { method: 'GET', path: '/token', handler: sendToken, config: { auth: 'jwt' } },
+      { method: 'GET', path: '/artifacts', handler: sendArtifacts, config: { auth:  'jwt' } },
       { method: 'POST', path: '/privado', handler: privado, config: { auth: 'jwt' } },
       { method: 'POST', path: '/privadonourl', handler: privado, config: { auth: 'jwt-nourl' } },
       { method: 'POST', path: '/privadonocookie', handler: privado, config: { auth: 'jwt-nocookie' } },


### PR DESCRIPTION
Use [request.auth.artifacts][0] to store a copy of the raw token and
decoded payload.

### Breaking Changes

`request.auth.artifacts` is now an object containing the raw token and
`decoded` `token` fields instead of a string.

### Migration Checklist

Artifacts are populated using the decoded (unvalidated) and raw token
objects for easy access on the validation callback or any
authentication-related actions.

#### Checklist:
- Look for `request.auth.artifacts` in your codebase and replace it with
  `request.auth.artifacts.token`

Closes #224 and #284

[0]: https://hapi.dev/api/?v=19.1.1#-requestauth