### PR TITLE
feat: store raw and decoded token under artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,29 @@ is documented on the Github [Releases](https://github.com/dwyl/hapi-auth-jwt2/re
 
 If anything is unclear in the project documentation, please
 raise an issue: https://github.com/dwyl/hapi-auth-jwt2/issues (_we are here to help!_)
+
+# Version 10.0.0
+
+Version 10.0.0 introduces a ***breaking change***
+where the returned `payload` `Object`
+now contains an `artifacts` `Object` of the form:
+
+```js
+return {
+  payload: {
+    credentials: credentials
+    artifacts: {
+      token,
+      decoded,
+    },
+  },
+};
+```
+
+Previously the value of `artifacts` was just the `token`.
+Anyone using version `9.0.0` will need to make the minor update
+to use `payload.artifacts.token` as opposed to `payload.artifacts`.
+
+# Version 9.0.0
+
+Version 9.0.0 is compatible with Hapi 19.x.x

--- a/README.md
+++ b/README.md
@@ -462,12 +462,12 @@ server.auth.default('jwt'); // so JWT auth is required for all routes
 
 When you want a particular route to ***not require*** JWT auth you simply set `config: { auth: false }` e.g:
 ```js
-  server.route({
-    method: 'GET',
-    path: '/login',
-    handler: login_handler,  // display login/registration form/page
-    options: { auth: false } // don't require people to be logged in to see the login page! (duh!)
-  });
+server.route({
+  method: 'GET',
+  path: '/login',
+  handler: login_handler,  // display login/registration form/page
+  options: { auth: false } // don't require people to be logged in to see the login page! (duh!)
+});
 ```
 
 The best place to _understand_ everything about Hapi Auth is in the docs: http://hapijs.com/tutorials/auth#setting-a-default-strategy
@@ -536,29 +536,33 @@ The only way to pass a token in this case is to use either an HTML form with the
 To configure `hapi-auth-jwt` to support this scenario, you will need to adapt the following sample configuration
 ```js
 server.auth.strategy('jwt', 'jwt', {
-      key: 'NeverShareYourSecret',
-      // defining our own validate function lets us do something
-      // useful/custom with the decodedToken before reply(ing)
-      validate: (decoded, request) => true,
-      verifyOptions: { algorithms: [ 'HS256' ] }, // only allow HS256 algorithm
-      attemptToExtractTokenInPayload: true,
-      // using yar as a session cache to store tokens, see: https://github.com/hapijs/yar
-      customExtractionFunc: request => {
-        if (request.auth && request.auth.token) {
-          request.yar.set('token', request.auth.token)
-          return request.auth.token;
-        }
-        const token = request.yar.get('token');
-        if (token) {
-          return token;
-        }
-      }
-    });
+  key: 'NeverShareYourSecret',
+  // defining our own validate function lets us do something
+  // useful/custom with the decodedToken before reply(ing)
+  validate: (decoded, request) => true,
+  verifyOptions: { algorithms: [ 'HS256' ] }, // only allow HS256 algorithm
+  attemptToExtractTokenInPayload: true,
+  // using yar as a session cache to store tokens, see: https://github.com/hapijs/yar
+  customExtractionFunc: request => {
+    if (request.auth && request.auth.token) {
+      request.yar.set('token', request.auth.token)
+      return request.auth.token;
+    }
+    const token = request.yar.get('token');
+    if (token) {
+      return token;
+    }
+  }
+});
 ```
 
 The configuration above will still run the normal token extraction attempts for headers, cookies, query string parameters and custom extraction. However, if there is no token successfully extracted, it will attempt to extract one from POST request bodies
 
-As the authentication phase of a HAPI request will apply scope protection before POST bodies are parsed, you will need to also define the route on which you will handle JWTs with no scope applied or the POST requests with JWT payloads will fail when you globally apply scope as part of your application
+As the authentication phase of a HAPI request will apply scope protection
+before POST bodies are parsed, you will need to also define the route on
+which you will handle JWTs with no scope applied or the POST requests with
+JWT payloads will fail when you globally apply scope as part of your
+application
 
 ```js
 server.route([
@@ -613,6 +617,13 @@ because with a `verify` you can incorporate your own custom-logic.
 
 ### Compatibility
 
+**`hapi-auth-jwt2`** version **`10.x.x`** is an ***optional upgrade***
+that includes a ***breaking change***.
+Several users of the plugin requested that the `artifacts`
+returned on successful authentication be an `Object` instead of a `String`.
+Sadly this is a breaking change, hence the new major release.
+
+
 **`hapi-auth-jwt2`** version **`9.x.x`** is compatible with **Hapi.js `19.x.x`**
 which only supports **Node.js 12+**.
 While **`hapi-auth-jwt2`** version `9.0.0`
@@ -623,9 +634,11 @@ we felt it was prudent to make it clear to people that Hapi.js
 [dropped support for Node.js 10](https://github.com/dwyl/hapi-auth-jwt2/issues/338#issuecomment-583716612)
 and people should treat _this_ package
 as no longer supporting the older versions of Node. <br />
+
 `hapi-auth-jwt2` version `8.x.x`
-is compatible with Hapi.js version `17.x.x` - `19.x.x`
-<br />`hapi-auth-jwt2` version `7.x.x` is compatible with `16.x.x`
+is compatible with Hapi.js version `17.x.x` - `19.x.x` <br />
+
+`hapi-auth-jwt2` version `7.x.x` is compatible with `16.x.x`
 `15.x.x` `14.x.x` `13.x.x` `12.x.x` `11.x.x` `10.x.x` `9.x.x` and `8.x.x`
 Hapi `17.x.x` is a _major_ rewrite that's why version `8.x.x`
 of the plugin is not backward compatible!

--- a/README.md
+++ b/README.md
@@ -400,8 +400,7 @@ http://tools.ietf.org/html/rfc6265
 
 - - -
 
-## Frequently Asked Questions (FAQ) [![Join the chat at https://gitter.im/dwyl/chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dwyl/chat/?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
+## Frequently Asked Questions (FAQ)
 
 ### Do I *need* to include `jsonwebtoken` in my project?
 
@@ -647,8 +646,7 @@ However in the interest of
  security/performance we *recommend* using the [*latest version*](https://github.com/hapijs/hapi/) of Hapi.
 
 > *If you have a question, or need help getting started* ***please post an issue/question on
-GitHub***: https://github.com/dwyl/hapi-auth-jwt2/issues *or*
-[![Join the chat at https://gitter.im/dwyl/chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dwyl/chat/?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+GitHub***: https://github.com/dwyl/hapi-auth-jwt2/issues
 
 <br />
 <br />

--- a/lib/index.js
+++ b/lib/index.js
@@ -193,7 +193,10 @@ internals.authenticate = async function(token, options, request, h) {
             credentials && typeof credentials === 'object'
               ? credentials
               : decoded,
-          artifacts: token,
+          artifacts: {
+            token,
+            decoded,
+          },
         },
       };
     } catch (validate_err) {
@@ -223,7 +226,10 @@ internals.authenticate = async function(token, options, request, h) {
     return {
       payload: {
         credentials: credentials,
-        artifacts: token,
+        artifacts: {
+          token,
+          decoded,
+        },
       },
     };
   } catch (verify_error) {
@@ -381,7 +387,7 @@ internals.implementation = function(server, options) {
     },
 
     verify: async function(auth) {
-      const token = auth.artifacts;
+      const token = auth.artifacts.token;
       const decoded = JWT.decode(token, {
         complete: options.complete || false,
       });

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
       "lib/**/*.js"
     ],
     "exclude": [
-      "test/**/*.spec.js"
+      "test/**/*.test.js"
     ],
     "reporter": [
       "lcov",
@@ -99,7 +99,7 @@
   "scripts": {
     "quick": "./node_modules/tape/bin/tape ./test/*.test.js | tap-nyc",
     "test": "nyc tape ./test/*.test.js | tap-nyc",
-    "coverage": "nyc tape ./test/*.test.js && nyc",
+    "coverage": "nyc tape ./test/*.test.js && nyc check-coverage",
     "lint": "eslint lib",
     "fixlint": "eslint lib --fix",
     "start": "node example/server.js",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
     {
       "name": "Steven Leadbeater",
       "user": "@LedSysUK <stevenleadbeater@live.co.uk>"
+    },
+    {
+      "name": "Gaston Festari",
+      "user": "@cilindrox <cilindrox@gmail.com>"
     }
   ],
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-auth-jwt2",
-  "version": "9.0.1",
+  "version": "10.0.0",
   "description": "Hapi.js Authentication Plugin/Scheme using JSON Web Tokens (JWT)",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@hapi/basic": "^6.0.0",
-    "@hapi/hapi": "^19.1.0",
+    "@hapi/hapi": "^19.1.1",
     "@types/hapi__hapi": "^19.0.1",
     "aguid": "^2.0.0",
     "eslint": "^7.0.0-alpha.0",

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -343,6 +343,27 @@ test("Scheme should set token in request.auth.token", async function(t) {
   t.end();
 });
 
+test("Scheme should set artifacts in request.auth.artifacts", async function(t) {
+
+  const token = JWT.sign({ id: 123, "name": "Charlie" }, secret);
+  const options = {
+    method: "GET",
+    url: "/artifacts",
+    headers: { authorization: "Bearer " + token }
+  };
+
+  const response = await server.inject(options);
+
+  const decoded = JWT.decode(token);
+  const artifacts = {
+    token,
+    decoded,
+  }
+
+  t.same(response.result, artifacts, 'Artifacts are accesible from handler');
+  t.end();
+})
+
 test.onFinish(function () {
   server.stop(function(){});
 })

--- a/test/basic_server.js
+++ b/test/basic_server.js
@@ -36,6 +36,10 @@ const sendToken = function(req, h) {
   return req.auth.token;
 };
 
+const sendArtifacts = function(req, h) {
+  return req.auth.artifacts;
+};
+
 const longRunning = async function(req, h) {
   await wait(1100);
   try {
@@ -96,6 +100,7 @@ const init = async () =>{
     server.route([
       { method: 'GET', path: '/', handler: home, config: { auth: false } },
       { method: 'GET', path: '/token', handler: sendToken, config: { auth: 'jwt' } },
+      { method: 'GET', path: '/artifacts', handler: sendArtifacts, config: { auth:  'jwt' } },
       { method: 'POST', path: '/privado', handler: privado, config: { auth: 'jwt' } },
       { method: 'POST', path: '/privadonourl', handler: privado, config: { auth: 'jwt-nourl' } },
       { method: 'POST', path: '/privadonocookie', handler: privado, config: { auth: 'jwt-nocookie' } },


### PR DESCRIPTION
Use [request.auth.artifacts][0] to store a copy of the raw token and
decoded payload.

### Breaking Changes

`request.auth.artifacts` is now an object containing the raw token and
`decoded` `token` fields instead of a string.

### Migration Checklist

Artifacts are populated using the decoded (unvalidated) and raw token
objects for easy access on the validation callback or any
authentication-related actions.

#### Checklist:
- Look for `request.auth.artifacts` in your codebase and replace it with
  `request.auth.artifacts.token`

Closes #224 and #284

[0]: https://hapi.dev/api/?v=19.1.1#-requestauth