### PR TITLE
Fix Options.key -type to include Buffer

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -46,7 +46,7 @@ declare namespace hapiAuthJwt2 {
         /**
          * The secret key used to check the signature of the token *or* a *key lookup function*
          */
-        key?: string | string[] | ((decodedToken: any) => Promise<{ key: string | string[]; extraInfo?: ExtraInfo }>);
+        key?: string | string[] | Buffer | ((decodedToken: any) => Promise<{ key: string | string[]; extraInfo?: ExtraInfo }>);
 
         /**
          * The function which is run once the Token has been decoded


### PR DESCRIPTION
According to README.md Buffer is the recommended type for base64 encoded keys but it isn't currently supported by the typings. This fixes that.