### PR TITLE
rename Hapi.Server to Hapi.server

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ const validate = async function (decoded, request, h) {
 
 const init = async () => {
   const server = new Hapi.server({ port: 8000 });
-  // include our module here ↓↓
+  // include our module here ↓↓, for example, require('hapi-auth-jwt2')
   await server.register(require('../lib'));
   server.auth.strategy('jwt', 'jwt',
   { key: 'NeverShareYourSecret', // Never Share your secret key

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const validate = async function (decoded, request, h) {
 };
 
 const init = async () => {
-  const server = new Hapi.Server({ port: 8000 });
+  const server = new Hapi.server({ port: 8000 });
   // include our module here ↓↓
   await server.register(require('../lib'));
   server.auth.strategy('jwt', 'jwt',

--- a/example/server.js
+++ b/example/server.js
@@ -34,7 +34,7 @@ const validate = async function (decoded, request, h) {
 };
 
 const init = async() => {
-  const server = new Hapi.Server({ port: port });
+  const server = new Hapi.server({ port: port });
   await server.register(hapiAuthJWT);
   // see: http://hapijs.com/api#serverauthschemename-scheme
   server.auth.strategy('jwt', 'jwt',

--- a/example/simple_server.js
+++ b/example/simple_server.js
@@ -21,7 +21,7 @@ const validate = async function (decoded, request, h) {
 
 const init = async () => {
   const server = new Hapi.server({ port: 8000 });
-  // include our module here ↓↓
+  // include our module here ↓↓, for example, require('hapi-auth-jwt2')
   await server.register(require('../lib'));
   server.auth.strategy('jwt', 'jwt',
   { key: 'NeverShareYourSecret', // Never Share your secret key

--- a/example/simple_server.js
+++ b/example/simple_server.js
@@ -20,7 +20,7 @@ const validate = async function (decoded, request, h) {
 };
 
 const init = async () => {
-  const server = new Hapi.Server({ port: 8000 });
+  const server = new Hapi.server({ port: 8000 });
   // include our module here ↓↓
   await server.register(require('../lib'));
   server.auth.strategy('jwt', 'jwt',

--- a/test/basic_server.js
+++ b/test/basic_server.js
@@ -2,7 +2,7 @@ const Hapi   = require('@hapi/hapi');
 const secret = 'NeverShareYourSecret';
 
 // for debug options see: http://hapijs.com/tutorials/logging
-const server = new Hapi.Server({ debug: false });
+const server = new Hapi.server({ debug: false });
 
 const db = {
   "123": { allowed: true,  "name": "Charlie"  },

--- a/test/complete_token.test.js
+++ b/test/complete_token.test.js
@@ -5,7 +5,7 @@ const secret = 'NeverShareYourSecret';
 
 const keyDict = { 5678: secret };
 
-const server = new Hapi.Server();
+const server = new Hapi.server();
 // server.connection();
 
 

--- a/test/custom_extraction_auth_server.js
+++ b/test/custom_extraction_auth_server.js
@@ -2,7 +2,7 @@ const Hapi   = require('@hapi/hapi');
 const secret = 'NeverShareYourSecret';
 
 // for debug options see: http://hapijs.com/tutorials/logging
-const server = new Hapi.Server({ debug: false });
+const server = new Hapi.server({ debug: false });
 
 const db = {
   "123": { allowed: true,  "name": "Charlie"  },

--- a/test/custom_parameters_server.js
+++ b/test/custom_parameters_server.js
@@ -2,7 +2,7 @@ const Hapi   = require('@hapi/hapi');
 const secret = 'NeverShareYourSecret';
 
 // for debug options see: http://hapijs.com/tutorials/logging
-const server = new Hapi.Server({ debug: false });
+const server = new Hapi.server({ debug: false });
 
 const db = {
   "123": { allowed: true,  "name": "Charlie" },

--- a/test/dynamic_header_key.test.js
+++ b/test/dynamic_header_key.test.js
@@ -7,7 +7,7 @@ const keyDict = { 5678: secret };
 
 test('When using a custom header key full token payload (header + payload + signature) is available to key lookup function using completeToken option', async function (t) {
 
-  const server = new Hapi.Server();
+  const server = new Hapi.server();
   try {
     await server.register(require('../'));
   } catch(e) {

--- a/test/dynamic_key_server.js
+++ b/test/dynamic_key_server.js
@@ -2,7 +2,7 @@ const Hapi = require('@hapi/hapi');
 const Boom = require('@hapi/boom');
 
 // for debug options see: http://hapijs.com/tutorials/logging
-const server = new Hapi.Server({ debug: false });
+const server = new Hapi.server({ debug: false });
 
 const multiTenantSecretKeys = {
   dunderMifflin: 'michaelscott',

--- a/test/error_func_server.js
+++ b/test/error_func_server.js
@@ -5,7 +5,7 @@ const secret = 'NeverShareYourSecret';
 let debug;
 // debug = { debug: { 'request': ['error', 'uncaught'] } };
 debug = { debug: false };
-const server = new Hapi.Server(debug);
+const server = new Hapi.server(debug);
 
 const sendToken = function(req, reply) {
   return req.auth.token || null;

--- a/test/multi_auth_server.js
+++ b/test/multi_auth_server.js
@@ -2,7 +2,7 @@ const Hapi = require('@hapi/hapi');
 const secret = 'NeverShareYourSecret';
 
 // for debug options see: http://hapijs.com/tutorials/logging
-const server = new Hapi.Server({ debug: false });
+const server = new Hapi.server({ debug: false });
 
 const db = {
   '123': { allowed: true, name: 'Charlie' },

--- a/test/multiple_key_server.js
+++ b/test/multiple_key_server.js
@@ -2,7 +2,7 @@ const Hapi = require('@hapi/hapi');
 const Boom = require('@hapi/boom');
 
 // for debug options see: http://hapijs.com/tutorials/logging
-const server = new Hapi.Server({ debug: false });
+const server = new Hapi.server({ debug: false });
 
 const multiTenantSecretKeys = {
   dunderMifflin: ['michaelscott', 'jimhalpert'],

--- a/test/options_payload_validation.js
+++ b/test/options_payload_validation.js
@@ -39,7 +39,7 @@ internals.payload = function (request, reply) {
 
 };
 
-var server = new Hapi.Server();
+var server = new Hapi.server();
 server.connection();
 
 function handler (request, reply) {

--- a/test/payload_auth_server.js
+++ b/test/payload_auth_server.js
@@ -2,7 +2,7 @@ const Hapi   = require('@hapi/hapi');
 const secret = 'NeverShareYourSecret';
 
 // for debug options see: http://hapijs.com/tutorials/logging
-const server = new Hapi.Server({ debug: false });
+const server = new Hapi.server({ debug: false });
 
 const db = {
   "123": { allowed: true,  "name": "Charlie"  },

--- a/test/scheme-payload-server.js
+++ b/test/scheme-payload-server.js
@@ -3,7 +3,7 @@ const secret = 'NeverShareYourSecret';
 const Boom = require('@hapi/boom');
 
 // for debug options see: http://hapijs.com/tutorials/logging
-const server = new Hapi.Server({ debug: false });
+const server = new Hapi.server({ debug: false });
 
 // payload is not available to validate, so payloadFunc offers a chance use it for validation
 const payloadFunction = function (req, h) {

--- a/test/scheme-response-server.js
+++ b/test/scheme-response-server.js
@@ -2,7 +2,7 @@ const Hapi   = require('@hapi/hapi');
 const secret = 'NeverShareYourSecret';
 
 // for debug options see: http://hapijs.com/tutorials/logging
-const server = new Hapi.Server({ debug: false });
+const server = new Hapi.server({ debug: false });
 
 const db = {
     "123": { allowed: true,  "name": "Charlie"  },

--- a/test/scopes_server.js
+++ b/test/scopes_server.js
@@ -2,7 +2,7 @@ const Hapi   = require('@hapi/hapi');
 const secret = 'NeverShareYourSecret';
 
 // for debug options see: http://hapijs.com/tutorials/logging
-const server = new Hapi.Server({ debug: false });
+const server = new Hapi.server({ debug: false });
 
 const db = {
   "123": { allowed: true,  "name": "Charlie"   },

--- a/test/try_and_optional_auth_mode.test.js
+++ b/test/try_and_optional_auth_mode.test.js
@@ -6,7 +6,7 @@ const secret = 'NeverShareYourSecret';
 test('Auth mode \'try\' should not set isAuthenticated to true when no token sent', async function (t) {
   t.plan(2);
 
-  const server = new Hapi.Server({ debug: {"request": ["error", "uncaught"]} });
+  const server = new Hapi.server({ debug: {"request": ["error", "uncaught"]} });
   
   try {
     await server.register(require('../'));
@@ -50,7 +50,7 @@ test('Auth mode \'try\' should not set isAuthenticated to true when no token sen
 test('Auth mode \'optional\' should not set isAuthenticated to true when no token sent', async function (t) {
   t.plan(3);
 
-  const server = new Hapi.Server();
+  const server = new Hapi.server();
 
   try{
     server.register(require('../'))

--- a/test/validate_func.test.js
+++ b/test/validate_func.test.js
@@ -5,7 +5,7 @@ const secret = 'NeverShareYourSecret';
 
 test('Should respond with 500 series error when validate errs', async function (t) {
 
-  const server = new Hapi.Server({ debug: false });
+  const server = new Hapi.server({ debug: false });
   try {
     await server.register(require('../'));
   } catch (err) {

--- a/test/verify_func_server.js
+++ b/test/verify_func_server.js
@@ -5,7 +5,7 @@ const secret = 'NeverShareYourSecret';
 let debug;
 // debug = { debug: { 'request': ['error', 'uncaught'] } };
 debug = { debug: false };
-const server = new Hapi.Server(debug);
+const server = new Hapi.server(debug);
 
 const sendToken = function(req, h) {
   return req.auth.token || null;


### PR DESCRIPTION
To keep it consistent with Hapi documentation - https://hapi.dev/tutorials/?lang=en_US#-creating-a-server,

As per documentation, they use lower case when creating a server - `Hapi.server`, this change is to just follow that convention and to keep it consistent.