### PR TITLE
Fix for #328 - treat JWT.decode() null return the same as if it threw an exception

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -128,6 +128,14 @@ internals.authenticate = async function(token, options, request, h) {
   try {
     decoded = JWT.decode(token, { complete: options.complete || false });
   } catch (e) {
+    // fix for https://github.com/dwyl/hapi-auth-jwt2/issues/328 -
+    // JWT.decode() can fail either by throwing an exception or by
+    // returning null, so here we just fall through to the following
+    // block that tests if decoded is not set, so that we can handle
+    // both failure types at once
+  }
+
+  if (!decoded) {
     return {
       error: internals.raiseError(
         options,
@@ -226,6 +234,11 @@ internals.authenticate = async function(token, options, request, h) {
   }
   // see: https://github.com/dwyl/hapi-auth-jwt2/issues/130
   try {
+    // note: at this point, we know options.verify must be non-null,
+    // because options.validate or options.verify are required to have
+    // been provided, and if options.validate were non-null, then we
+    // would have hit the above block and already returned out of this
+    // function
     let { isValid, credentials } = await options.verify(decoded, request);
     if (!isValid) {
       return {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "aguid": "^2.0.0",
     "eslint": "^7.0.0-alpha.0",
     "eslint-plugin-prettier": "^3.1.2",
+    "ms": "^2.1.1",
     "nyc": "^15.0.0",
     "pre-commit": "^1.2.2",
     "prettier": "^1.19.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "aguid": "^2.0.0",
     "eslint": "^7.0.0-alpha.0",
     "eslint-plugin-prettier": "^3.1.2",
-    "ms": "^2.1.1",
     "nyc": "^15.0.0",
     "pre-commit": "^1.2.2",
     "prettier": "^1.19.1",

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -44,7 +44,7 @@ test("Malformed JWT", async function(t) {
 
   // assert on the response message, so we can ensure this case fails
   // early (after decode()) with "Invalid token format" instead of too
-  // later (after verify) with "Invalid token"
+  // late (after verify) with "Invalid token"
   t.equal(response.result.message, 'Invalid token format', 'Message should be "Invalid token format"');
   t.end();
 });

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -41,7 +41,11 @@ test("Malformed JWT", async function(t) {
   // console.log(response.result);
   // console.log(' '); // blank line
   t.equal(response.statusCode, 401, "INVALID Token should fail");
-  // t.equal(JSON.parse(response.result).msg, 'Invalid Token', "INVALID Token should fail");
+
+  // assert on the response message, so we can ensure this case fails
+  // early (after decode()) with "Invalid token format" instead of too
+  // later (after verify) with "Invalid token"
+  t.equal(response.result.message, 'Invalid token format', 'Message should be "Invalid token format"');
   t.end();
 });
 


### PR DESCRIPTION
This prevents a custom verify() function from being called with
decoded=null, from which the function then has no way to avoid
producing a 500 response to the request.
