### PR TITLE
Switch to use Buffer.from

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ If your key is base64 encoded, then for JWT2 to use it you need to convert it to
 
 ```js
 server.auth.strategy('jwt', 'jwt', true,
-{ key: Buffer('<Your Base64 encoded secret key>', 'base64'), // Never Share your secret key
+{ key: Buffer.from('<Your Base64 encoded secret key>', 'base64'), // Never Share your secret key
   validate: validate,      // validate function defined above
   verifyOptions: { algorithms: [ 'HS256' ] }  // only allow HS256 algorithm
 });


### PR DESCRIPTION
Using Buffer in this way is deprecated, so I've simply changed it to use `Buffer.from()` which has the same interface.

https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/