### PR TITLE
Fix: http --> https for jwt.io URL in README.md fixes #309

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ This feature was requested in: [issues/29](https://github.com/dwyl/hapi-auth-jwt
 
 ### Using Base64 encoded secret keys
 
-Some authentication services (like Auth0) provide secret keys encoded in base64, To find out if your authentication service is one of these services, please try and experiment with the base64 encoded secret options on the validator at http://jwt.io/
+Some authentication services (like Auth0) provide secret keys encoded in base64, To find out if your authentication service is one of these services, please try and experiment with the base64 encoded secret options on the validator at https://jwt.io
 
 If your key is base64 encoded, then for JWT2 to use it you need to convert it to a buffer.  Following is an example of how to do this.
 


### PR DESCRIPTION
+ [x] Update link from http://jwt.io to https://jwt.io (https) as noted by @codeshifu in #309 