### PR TITLE
Issue #468 handle error object passed into raise error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -306,7 +306,7 @@ internals.raiseError = function raiseError(
     errorContext.error instanceof Error &&
     errorContext.errorType === 'boomify'
   ) {
-    error = Boom.boomify(errorOrMessage);
+    error = Boom.boomify(errorContext.error);
   } else {
     error = Boom[errorContext.errorType](
       errorContext.message,

--- a/lib/index.js
+++ b/lib/index.js
@@ -288,7 +288,7 @@ internals.raiseError = function raiseError(
   isMissingToken
 ) {
   let error;
-  if (errorOrMessage instanceof Error && errorContext.errorType === 'boomify') {
+  if (errorOrMessage instanceof Error && errorType === 'boomify') {
     error = Boom.boomify(errorOrMessage);
   }
   else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -287,26 +287,32 @@ internals.raiseError = function raiseError(
   extraContext,
   isMissingToken
 ) {
-  let errorContext = {
-    errorType: errorType,
-    message: errorOrMessage.toString(),
-    error: typeof errorOrMessage === 'object' ? errorOrMessage : undefined,
-  };
-  Object.assign(errorContext, extraContext);
-
-  if (internals.isFunction(options.errorFunc)) {
-    errorContext = options.errorFunc(errorContext, request, h);
+  let error;
+  if (errorOrMessage instanceof Error && errorContext.errorType === 'boomify') {
+    error = Boom.boomify(errorOrMessage);
   }
-  // Since it is clearly specified in the docs that
-  // the errorFunc must return an object with keys:
-  // errorType and message, we need not worry about
-  // errorContext being undefined
+  else {
+    let errorContext = {
+      errorType: errorType,
+      message: errorOrMessage.toString(),
+      error: typeof errorOrMessage === 'object' ? errorOrMessage : undefined,
+    };
+    Object.assign(errorContext, extraContext);
 
-  const error = Boom[errorContext.errorType](
-    errorContext.message,
-    errorContext.scheme,
-    errorContext.attributes
-  );
+    if (internals.isFunction(options.errorFunc)) {
+      errorContext = options.errorFunc(errorContext, request, h);
+    }
+    // Since it is clearly specified in the docs that
+    // the errorFunc must return an object with keys:
+    // errorType and message, we need not worry about
+    // errorContext being undefined
+  
+    error = Boom[errorContext.errorType](
+      errorContext.message,
+      errorContext.scheme,
+      errorContext.attributes
+      );
+  }
 
   return isMissingToken
     ? Object.assign(error, {

--- a/lib/index.js
+++ b/lib/index.js
@@ -287,31 +287,32 @@ internals.raiseError = function raiseError(
   extraContext,
   isMissingToken
 ) {
-  let error;
-  if (errorOrMessage instanceof Error && errorType === 'boomify') {
-    error = Boom.boomify(errorOrMessage);
-  }
-  else {
-    let errorContext = {
-      errorType: errorType,
-      message: errorOrMessage.toString(),
-      error: typeof errorOrMessage === 'object' ? errorOrMessage : undefined,
-    };
-    Object.assign(errorContext, extraContext);
+  let errorContext = {
+    errorType: errorType,
+    message: errorOrMessage.toString(),
+    error: typeof errorOrMessage === 'object' ? errorOrMessage : undefined,
+  };
+  Object.assign(errorContext, extraContext);
 
-    if (internals.isFunction(options.errorFunc)) {
-      errorContext = options.errorFunc(errorContext, request, h);
-    }
-    // Since it is clearly specified in the docs that
-    // the errorFunc must return an object with keys:
-    // errorType and message, we need not worry about
-    // errorContext being undefined
-  
+  if (internals.isFunction(options.errorFunc)) {
+    errorContext = options.errorFunc(errorContext, request, h);
+  }
+  // Since it is clearly specified in the docs that
+  // the errorFunc must return an object with keys:
+  // errorType and message, we need not worry about
+  // errorContext being undefined
+  let error;
+  if (
+    errorContext.error instanceof Error &&
+    errorContext.errorType === 'boomify'
+  ) {
+    error = Boom.boomify(errorOrMessage);
+  } else {
     error = Boom[errorContext.errorType](
       errorContext.message,
       errorContext.scheme,
       errorContext.attributes
-      );
+    );
   }
 
   return isMissingToken

--- a/test/validate_func.test.js
+++ b/test/validate_func.test.js
@@ -13,11 +13,6 @@ test('Should respond with 500 when validate function throws an error', async fun
 
   let response = await server.inject(options);
   t.equal(response.statusCode, 500, 'Server returned 500 for validate error');
-  // t.equal(
-  //   response.result.message,
-  //   'ASPLODE',
-  //   'Error message when validation function throws an error'
-  // );
   t.end();
 });
 
@@ -72,6 +67,27 @@ test('Should respond with custom error message when validate function returns cu
     response.result.message,
     'Bad ID',
     'Custom error message for invalid credentials'
+  );
+  t.end();
+});
+
+test('Should respond with non-generic error message when validate function throws a non-server error', async function (t) {
+  let options = {
+    method: 'POST',
+    url: '/privado',
+    headers: { Authorization: JWT.sign({ id: 141, name: 'Test' }, secret) },
+  };
+
+  let response = await server.inject(options);
+  t.equal(
+    response.statusCode,
+    404,
+    'Server returned 404 for resource not found'
+  );
+  t.equal(
+    response.result.message,
+    'Resource not found',
+    'Error message for resource not found'
   );
   t.end();
 });

--- a/test/validate_func.test.js
+++ b/test/validate_func.test.js
@@ -1,61 +1,77 @@
-const test   = require('tape');
-const Hapi   = require('@hapi/hapi');
-const JWT    = require('jsonwebtoken');
+const test = require('tape');
+const JWT = require('jsonwebtoken');
 const secret = 'NeverShareYourSecret';
 
-test('Should respond with 500 series error when validate errs', async function (t) {
+const server = require('./validate_func_server'); // test server which in turn loads our module
 
-  const server = new Hapi.server({ debug: false });
-  try {
-    await server.register(require('../'));
-  } catch (err) {
-    t.ifError(err, 'No error registering hapi-auth-jwt2 plugin');
-  }
-  server.auth.strategy('jwt', 'jwt', {
-    key: secret,
-    validate: function (decoded, request, h) {
-      if (decoded.id === 138) {
-        throw new Error('ASPLODE');
-      }
-      if (decoded.id === 139) {
-        return { isValid: false }
-      }
-      if (decoded.id === 140) {
-        return { isValid: false, errorMessage: 'Bad ID' }
-      }
-      return { response:  h.redirect('https://dwyl.com') }
-    },
-    verifyOptions: {algorithms: ['HS256']}
-  });
-
-  server.route({
-    method: 'POST',
-    path: '/privado',
-    handler: function (req, h) { return 'PRIVADO'; },
-    config: { auth: 'jwt' }
-  });
-
+test('Should respond with 500 when validate function throws an error', async function (t) {
   let options = {
     method: 'POST',
     url: '/privado',
-    headers: {Authorization: JWT.sign({id: 138, name: 'Test'}, secret)}
+    headers: { Authorization: JWT.sign({ id: 138, name: 'Test' }, secret) },
   };
 
   let response = await server.inject(options);
   t.equal(response.statusCode, 500, 'Server returned 500 for validate error');
+  // t.equal(
+  //   response.result.message,
+  //   'ASPLODE',
+  //   'Error message when validation function throws an error'
+  // );
+  t.end();
+});
 
-  options.headers.Authorization = JWT.sign({ id: 200, name: 'Test' }, secret);
-  response = await server.inject(options);
-  t.equal(response.statusCode, 302, 'Server redirect status code');
-  t.equal(response.headers.location, 'https://dwyl.com', 'Server redirect header');
+test('Should redirect when validate function returns a response object with redirect', async function (t) {
+  let options = {
+    method: 'POST',
+    url: '/privado',
+    headers: { Authorization: JWT.sign({ id: 200, name: 'Test' }, secret) },
+  };
 
-  options.headers.Authorization = JWT.sign({id: 139, name: 'Test'}, secret);
-  response = await server.inject(options);
-  t.equal(response.statusCode, 401, 'Server errors when isValid false');
-  t.equal(response.result.message, 'Invalid credentials', 'Default error message when custom not provided');
+  let response = await server.inject(options);
+  t.equal(response.statusCode, 302, 'Server redirected successfully');
+  t.equal(
+    response.headers.location,
+    'https://dwyl.com',
+    'Server redirected to correct URL'
+  );
+  t.end();
+});
 
-  options.headers.Authorization = JWT.sign({id: 140, name: 'Test'}, secret);
-  response = await server.inject(options);
-  t.equal(response.result.message, 'Bad ID', 'Custom error message when provided');
+test('Should respond with 401 when validate function returns isValid false', async function (t) {
+  let options = {
+    method: 'POST',
+    url: '/privado',
+    headers: { Authorization: JWT.sign({ id: 139, name: 'Test' }, secret) },
+  };
+
+  let response = await server.inject(options);
+  t.equal(
+    response.statusCode,
+    401,
+    'Server returned 401 for invalid credentials'
+  );
+  t.equal(
+    response.result.message,
+    'Invalid credentials',
+    'Default error message for invalid credentials'
+  );
+  t.end();
+});
+
+test('Should respond with custom error message when validate function returns custom errorMessage', async function (t) {
+  let options = {
+    method: 'POST',
+    url: '/privado',
+    headers: { Authorization: JWT.sign({ id: 140, name: 'Test' }, secret) },
+  };
+
+  let response = await server.inject(options);
+  t.equal(response.statusCode, 401, 'Server returned 401 for custom error');
+  t.equal(
+    response.result.message,
+    'Bad ID',
+    'Custom error message for invalid credentials'
+  );
   t.end();
 });

--- a/test/validate_func_server.js
+++ b/test/validate_func_server.js
@@ -1,0 +1,42 @@
+const Hapi = require('@hapi/hapi');
+const secret = 'NeverShareYourSecret';
+
+// for debug options see: https://hapi.dev/tutorials/logging/
+let debug;
+// debug = { debug: { 'request': ['error', 'uncaught'] } };
+debug = { debug: false };
+const server = new Hapi.server(debug);
+
+const init = async () => {
+  await server.register(require('../'));
+
+  server.auth.strategy('jwt', 'jwt', {
+    key: secret,
+    validate: function (decoded, request, h) {
+      if (decoded.id === 138) {
+        throw new Error('ASPLODE');
+      }
+      if (decoded.id === 139) {
+        return { isValid: false };
+      }
+      if (decoded.id === 140) {
+        return { isValid: false, errorMessage: 'Bad ID' };
+      }
+      return { response: h.redirect('https://dwyl.com') };
+    },
+    verifyOptions: { algorithms: ['HS256'] },
+  });
+
+  server.route({
+    method: 'POST',
+    path: '/privado',
+    handler: function (req, h) {
+      return 'PRIVADO';
+    },
+    config: { auth: 'jwt' },
+  });
+};
+
+init();
+
+module.exports = server;

--- a/test/validate_func_server.js
+++ b/test/validate_func_server.js
@@ -1,3 +1,4 @@
+const Boom = require('@hapi/boom');
 const Hapi = require('@hapi/hapi');
 const secret = 'NeverShareYourSecret';
 
@@ -21,6 +22,9 @@ const init = async () => {
       }
       if (decoded.id === 140) {
         return { isValid: false, errorMessage: 'Bad ID' };
+      }
+      if (decoded.id === 141) {
+        throw Boom.notFound('Resource not found');
       }
       return { response: h.redirect('https://dwyl.com') };
     },


### PR DESCRIPTION
Code to address bug in Issue #468 https://github.com/dwyl/hapi-auth-jwt2/issues/468

Added a check for an error object passed into the method with "boomify" and handle it accordingly so boom will not throw an "Unable to wrap non-error object" error.

Tidied up the validate_func tests to match other test files with a separate server setup. This allowed for better debugging in my experience.

Separated out tests into specific cases.

Techncially the 'ASPLODE' test was also impacted by this bug, but the test did not catch it because the Hapi server wraps any 500 error in a generic "Internal Server Error" message, so I added a new case that throws a 404 error and is broken without the bug fix.