### PR TITLE
PR: Release new version with `"type": "module"` & `.js` -> `.cjs`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3547,9 +3547,10 @@
     "node_modules/pre-commit": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
-      "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
+      "integrity": "sha512-qokTiqxD6GjODy5ETAIgzsRgnBWWQHQH2ghy86PU7mIn/wuWeTwF3otyNQZxWBwVn8XNr8Tdzj/QfUXpH+gRZA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^5.0.1",
         "spawn-sync": "^1.0.15",
@@ -3559,8 +3560,9 @@
     "node_modules/pre-commit/node_modules/cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
@@ -4098,8 +4100,9 @@
     "node_modules/tap-nyc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tap-nyc/-/tap-nyc-1.0.3.tgz",
-      "integrity": "sha1-W2CAUuwPxZTejgxbdl+k6i/3VPg=",
+      "integrity": "sha512-s3yicc3YGitxZJj38VsVwyomO0k4D/HpwYV44ueGC1n0Edmg0EK1IC1CI8z2Qj8sI2tFawEQQRjyNmkvceUsIA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^1.0.0",
         "duplexer": "^0.1.1",
@@ -4184,8 +4187,9 @@
     "node_modules/tap-out": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/tap-out/-/tap-out-1.4.2.tgz",
-      "integrity": "sha1-yQfsG/lAURHQiCY+kvVgi4jLs3o=",
+      "integrity": "sha512-66lGHiYP7ZJKnAuY0FQTi2e5N+IT7m+q1CMbyAb+XqbfdF+ZuDJEwu8NP3PKErKyrq9pVL+r/EflB+N5IanBog==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "re-emitter": "^1.0.0",
         "readable-stream": "^2.0.0",
@@ -4289,7 +4293,8 @@
     "node_modules/trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+      "integrity": "sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==",
+      "deprecated": "Use String.prototype.trim() instead",
       "dev": true
     },
     "node_modules/ts-api-utils": {
@@ -7211,7 +7216,7 @@
     "pre-commit": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
-      "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
+      "integrity": "sha512-qokTiqxD6GjODy5ETAIgzsRgnBWWQHQH2ghy86PU7mIn/wuWeTwF3otyNQZxWBwVn8XNr8Tdzj/QfUXpH+gRZA==",
       "dev": true,
       "requires": {
         "cross-spawn": "^5.0.1",
@@ -7222,7 +7227,7 @@
         "cross-spawn": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
@@ -7611,7 +7616,7 @@
     "tap-nyc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tap-nyc/-/tap-nyc-1.0.3.tgz",
-      "integrity": "sha1-W2CAUuwPxZTejgxbdl+k6i/3VPg=",
+      "integrity": "sha512-s3yicc3YGitxZJj38VsVwyomO0k4D/HpwYV44ueGC1n0Edmg0EK1IC1CI8z2Qj8sI2tFawEQQRjyNmkvceUsIA==",
       "dev": true,
       "requires": {
         "chalk": "^1.0.0",
@@ -7678,7 +7683,7 @@
     "tap-out": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/tap-out/-/tap-out-1.4.2.tgz",
-      "integrity": "sha1-yQfsG/lAURHQiCY+kvVgi4jLs3o=",
+      "integrity": "sha512-66lGHiYP7ZJKnAuY0FQTi2e5N+IT7m+q1CMbyAb+XqbfdF+ZuDJEwu8NP3PKErKyrq9pVL+r/EflB+N5IanBog==",
       "dev": true,
       "requires": {
         "re-emitter": "^1.0.0",
@@ -7766,7 +7771,7 @@
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+      "integrity": "sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==",
       "dev": true
     },
     "ts-api-utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hapi-auth-jwt2",
-  "version": "10.7.0",
+  "version": "11.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hapi-auth-jwt2",
-      "version": "10.7.0",
+      "version": "11.0.0",
       "license": "ISC",
       "dependencies": {
         "@hapi/boom": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-auth-jwt2",
-  "version": "10.7.0",
+  "version": "11.0.0",
   "description": "Hapi.js Authentication Plugin/Scheme using JSON Web Tokens (JWT)",
   "main": "lib/index.cjs",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
This PR releases a new version of the package to conform to the latest `eslint` requirements. #508 + #509 
No library code was changed therefore there should not be any _breaking_ changes downstream.
But we are releasing it as a new `major` version just-in-case the `"type": "module"` breaks anything 
and we don't end up taking down someone's app/site. 💭 

