### PR TITLE
fix resolve typescript mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Hapi.js Authentication Plugin/Scheme using JSON Web Tokens (JWT)",
   "main": "lib/index.cjs",
   "types": "lib/index.d.ts",
-  "type": "module",
+  "type": "commonjs",
   "repository": {
     "type": "git",
     "url": "https://github.com/dwyl/hapi-auth-jwt2.git"


### PR DESCRIPTION
Fixes #511

The package.json declared "type": "module", but the library is implemented using CommonJS. This mismatch causes TypeScript import errors.

Updated the module type to "commonjs" to align with the actual implementation and resolve the issue.